### PR TITLE
Enable custom state adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ config :samly, Samly.Provider,
 | Parameters | Description |
 |:------------|:-----------|
 | `idp_id_from` | _(optional)_`:path_segment` or `:subdomain`. Default is `:path_segment`. |
+| `state_adapter` | _(optional)_ State provider. Samly comes bundled with ETS
+state provider, but you may implement your own. Default is `Samly.State.Ets`. |
 | **Service Provider Parameters** | |
 | `id` | _(mandatory)_ |
 | `identity_id` | _(optional)_ If omitted, the metadata URL will be used |
@@ -280,7 +282,7 @@ config :samly, Samly.Provider,
     %{
       # ...
       pre_session_create_pipeline: MySamlyPipeline,
-      # ...    
+      # ...
     }
   ]
 ```

--- a/lib/samly.ex
+++ b/lib/samly.ex
@@ -17,11 +17,11 @@ defmodule Samly do
 
   - conn: Plug connection
   """
-  @spec get_active_assertion(Conn.t()) :: Assertion.t()
-  def get_active_assertion(conn) do
+  @spec get_active_assertion(Conn.t(), String.t()) :: Assertion.t()
+  def get_active_assertion(conn, idp_id) do
     nameid = conn |> Conn.get_session("samly_nameid")
 
-    case State.get_by_nameid(nameid) do
+    case State.get_by_nameid(idp_id, nameid) do
       {^nameid, saml_assertion} -> saml_assertion
       _ -> nil
     end

--- a/lib/samly/auth_handler.ex
+++ b/lib/samly/auth_handler.ex
@@ -53,7 +53,7 @@ defmodule Samly.AuthHandler do
     target_url = (conn.params["target_url"] || "/") |> URI.decode_www_form()
     nameid = get_session(conn, "samly_nameid")
 
-    case State.get_by_nameid(nameid) do
+    case State.get_by_nameid(idp_id, nameid) do
       {^nameid, %Assertion{idp_id: ^idp_id}} ->
         conn |> redirect(302, target_url)
 
@@ -88,7 +88,7 @@ defmodule Samly.AuthHandler do
     target_url = (conn.params["target_url"] || "/") |> URI.decode_www_form()
     nameid = get_session(conn, "samly_nameid")
 
-    case State.get_by_nameid(nameid) do
+    case State.get_by_nameid(idp_id, nameid) do
       {^nameid, %Assertion{idp_id: ^idp_id, authn: authn, subject: subject}} ->
         session_index = Map.get(authn, "session_index", "")
         subject_rec = Subject.to_rec(subject)

--- a/lib/samly/idp_data.ex
+++ b/lib/samly/idp_data.ex
@@ -150,14 +150,13 @@ defmodule Samly.IdpData do
 
   @spec cert_config_ok?(%IdpData{}, %SpData{}) :: boolean
   defp cert_config_ok?(%IdpData{} = idp_data, %SpData{} = sp_data) do
-    if (idp_data.sign_metadata ||
-        idp_data.sign_requests ) &&
-        (sp_data.cert == :undefined || sp_data.key == :undefined) do
-          Logger.error("[Samly] SP cert or key missing - Skipping identity provider: #{idp_data.id}")
-          false
-        else
-          true
-        end
+    if (idp_data.sign_metadata || idp_data.sign_requests) &&
+         (sp_data.cert == :undefined || sp_data.key == :undefined) do
+      Logger.error("[Samly] SP cert or key missing - Skipping identity provider: #{idp_data.id}")
+      false
+    else
+      true
+    end
   end
 
   @default_metadata_file "idp_metadata.xml"

--- a/lib/samly/sp_data.ex
+++ b/lib/samly/sp_data.ex
@@ -83,6 +83,7 @@ defmodule Samly.SpData do
   defp load_cert(%SpData{certfile: ""} = sp_data, _) do
     %SpData{sp_data | cert: :undefined}
   end
+
   defp load_cert(%SpData{certfile: certfile} = sp_data, %{} = opts_map) do
     try do
       cert = :esaml_util.load_certificate(certfile)
@@ -98,6 +99,7 @@ defmodule Samly.SpData do
   defp load_key(%SpData{keyfile: ""} = sp_data, _) do
     %SpData{sp_data | key: :undefined}
   end
+
   defp load_key(%SpData{keyfile: keyfile} = sp_data, %{} = opts_map) do
     try do
       key = :esaml_util.load_private_key(keyfile)

--- a/lib/samly/sp_handler.ex
+++ b/lib/samly/sp_handler.ex
@@ -44,7 +44,7 @@ defmodule Samly.SPHandler do
 
       # TODO: use idp_id + nameid
       nameid = assertion.subject.name
-      State.put(nameid, assertion)
+      State.put(idp_id, nameid, assertion)
       target_url = auth_target_url(conn, assertion, relay_state)
 
       conn
@@ -160,13 +160,13 @@ defmodule Samly.SPHandler do
       Esaml.esaml_logoutreq(name: nameid, issuer: _issuer) = payload
 
       return_status =
-        case State.get_by_nameid(nameid) do
+        case State.get_by_nameid(idp_id, nameid) do
           {^nameid, %Assertion{idp_id: ^idp_id}} ->
-            State.delete(nameid)
+            State.delete(idp_id, nameid)
             :success
 
           {^nameid, _saml_assertion} ->
-            State.delete(nameid)
+            State.delete(idp_id, nameid)
             :denied
 
           _ ->

--- a/lib/samly/state.ex
+++ b/lib/samly/state.ex
@@ -1,17 +1,19 @@
 defmodule Samly.State do
   @moduledoc false
 
-  @adapter Application.get_env(:samly, Samly.Provider)[:state_adapter] || Samly.State.Ets
-
   def gen_id() do
     24 |> :crypto.strong_rand_bytes() |> Base.url_encode64()
   end
 
-  def init(), do: @adapter.init()
+  def init(), do: adapter().init()
 
-  def get_by_nameid(idp_id, nameid), do: @adapter.get_by_nameid(idp_id, nameid)
+  def get_by_nameid(idp_id, nameid), do: adapter().get_by_nameid(idp_id, nameid)
 
-  def put(idp_id, nameid, saml_assertion), do: @adapter.put(idp_id, nameid, saml_assertion)
+  def put(idp_id, nameid, saml_assertion), do: adapter().put(idp_id, nameid, saml_assertion)
 
-  def delete(idp_id, nameid), do: @adapter.delete(idp_id, nameid)
+  def delete(idp_id, nameid), do: adapter().delete(idp_id, nameid)
+
+  defp adapter do
+    Application.get_env(:samly, Samly.Provider)[:state_adapter] || Samly.State.Ets
+  end
 end

--- a/lib/samly/state.ex
+++ b/lib/samly/state.ex
@@ -1,28 +1,17 @@
 defmodule Samly.State do
   @moduledoc false
 
-  def init() do
-    if :ets.info(:esaml_nameids) == :undefined do
-      :ets.new(:esaml_nameids, [:set, :public, :named_table])
-    end
-  end
+  @adapter Application.get_env(:samly, :state_adapter) || Samly.State.Ets
 
   def gen_id() do
     24 |> :crypto.strong_rand_bytes() |> Base.url_encode64()
   end
 
-  def get_by_nameid(nameid) do
-    case :ets.lookup(:esaml_nameids, nameid) do
-      [{_nameid, _saml_assertion} = rec] -> rec
-      _ -> nil
-    end
-  end
+  def init(), do: @adapter.init()
 
-  def put(nameid, saml_assertion) do
-    :ets.insert(:esaml_nameids, {nameid, saml_assertion})
-  end
+  def get_by_nameid(nameid), do: @adapter.get_by_nameid(nameid)
 
-  def delete(nameid) do
-    :ets.delete(:esaml_nameids, nameid)
-  end
+  def put(nameid, saml_assertion), do: @adapter.put(nameid, saml_assertion)
+
+  def delete(nameid), do: @adapter.delete(nameid)
 end

--- a/lib/samly/state.ex
+++ b/lib/samly/state.ex
@@ -1,7 +1,7 @@
 defmodule Samly.State do
   @moduledoc false
 
-  @adapter Application.get_env(:samly, :state_adapter) || Samly.State.Ets
+  @adapter Application.get_env(:samly, Samly.Provider)[:state_adapter] || Samly.State.Ets
 
   def gen_id() do
     24 |> :crypto.strong_rand_bytes() |> Base.url_encode64()

--- a/lib/samly/state.ex
+++ b/lib/samly/state.ex
@@ -9,9 +9,9 @@ defmodule Samly.State do
 
   def init(), do: @adapter.init()
 
-  def get_by_nameid(nameid), do: @adapter.get_by_nameid(nameid)
+  def get_by_nameid(idp_id, nameid), do: @adapter.get_by_nameid(idp_id, nameid)
 
-  def put(nameid, saml_assertion), do: @adapter.put(nameid, saml_assertion)
+  def put(idp_id, nameid, saml_assertion), do: @adapter.put(idp_id, nameid, saml_assertion)
 
-  def delete(nameid), do: @adapter.delete(nameid)
+  def delete(idp_id, nameid), do: @adapter.delete(idp_id, nameid)
 end

--- a/lib/samly/state/ets.ex
+++ b/lib/samly/state/ets.ex
@@ -7,10 +7,6 @@ defmodule Samly.State.Ets do
     end
   end
 
-  def gen_id() do
-    24 |> :crypto.strong_rand_bytes() |> Base.url_encode64()
-  end
-
   def get_by_nameid(nameid) do
     case :ets.lookup(:esaml_nameids, nameid) do
       [{_nameid, _saml_assertion} = rec] -> rec

--- a/lib/samly/state/ets.ex
+++ b/lib/samly/state/ets.ex
@@ -7,18 +7,18 @@ defmodule Samly.State.Ets do
     end
   end
 
-  def get_by_nameid(nameid) do
+  def get_by_nameid(_, nameid) do
     case :ets.lookup(:esaml_nameids, nameid) do
       [{_nameid, _saml_assertion} = rec] -> rec
       _ -> nil
     end
   end
 
-  def put(nameid, saml_assertion) do
+  def put(_, nameid, saml_assertion) do
     :ets.insert(:esaml_nameids, {nameid, saml_assertion})
   end
 
-  def delete(nameid) do
+  def delete(_, nameid) do
     :ets.delete(:esaml_nameids, nameid)
   end
 end

--- a/lib/samly/state/ets.ex
+++ b/lib/samly/state/ets.ex
@@ -1,0 +1,28 @@
+defmodule Samly.State.Ets do
+  @moduledoc false
+
+  def init() do
+    if :ets.info(:esaml_nameids) == :undefined do
+      :ets.new(:esaml_nameids, [:set, :public, :named_table])
+    end
+  end
+
+  def gen_id() do
+    24 |> :crypto.strong_rand_bytes() |> Base.url_encode64()
+  end
+
+  def get_by_nameid(nameid) do
+    case :ets.lookup(:esaml_nameids, nameid) do
+      [{_nameid, _saml_assertion} = rec] -> rec
+      _ -> nil
+    end
+  end
+
+  def put(nameid, saml_assertion) do
+    :ets.insert(:esaml_nameids, {nameid, saml_assertion})
+  end
+
+  def delete(nameid) do
+    :ets.delete(:esaml_nameids, nameid)
+  end
+end

--- a/test/samly_idp_data_test.exs
+++ b/test/samly_idp_data_test.exs
@@ -50,12 +50,17 @@ defmodule SamlyIdpDataTest do
     sp_data3 = SpData.load_provider(@sp_config3)
     sp_data4 = SpData.load_provider(@sp_config4)
     sp_data5 = SpData.load_provider(@sp_config5)
-    [sps: %{
-      sp_data1.id => sp_data1,
-      sp_data2.id => sp_data2,
-      sp_data3.id => sp_data3,
-      sp_data4.id => sp_data4,
-      sp_data5.id => sp_data5}] |> Enum.into(context)
+
+    [
+      sps: %{
+        sp_data1.id => sp_data1,
+        sp_data2.id => sp_data2,
+        sp_data3.id => sp_data3,
+        sp_data4.id => sp_data4,
+        sp_data5.id => sp_data5
+      }
+    ]
+    |> Enum.into(context)
   end
 
   test "valid-idp-config-1", %{sps: sps} do


### PR DESCRIPTION
We're using Samly in a load-balanced multi-host setup. Storing the assertion on ETS, thus, represents a problem, as the ETS state is not synced across the hosts by default. This PR makes it possible to configure the "state adapter", leaving the `Ets` adapter as default. With this, we're able to store the assertions on the DB.

Thanks!