### PR TITLE
Downcase header names

### DIFF
--- a/lib/samly/auth_handler.ex
+++ b/lib/samly/auth_handler.ex
@@ -41,7 +41,7 @@ defmodule Samly.AuthHandler do
     ]
 
     conn
-    |> put_resp_header("Content-Type", "text/html")
+    |> put_resp_header("content-type", "text/html")
     |> send_resp(200, EEx.eval_string(@sso_init_resp_template, opts))
   end
 

--- a/lib/samly/router.ex
+++ b/lib/samly/router.ex
@@ -18,11 +18,11 @@ defmodule Samly.Router do
     conn
     |> register_before_send(fn connection ->
       connection
-      |> put_resp_header("Cache-Control", "no-cache")
-      |> put_resp_header("Pragma", "no-cache")
-      |> put_resp_header("X-Frame-Options", "SAMEORIGIN")
-      |> put_resp_header("X-XSS-Protection", "1; mode=block")
-      |> put_resp_header("X-Content-Type-Options", "nosniff")
+      |> put_resp_header("cache-control", "no-cache")
+      |> put_resp_header("pragma", "no-cache")
+      |> put_resp_header("x-frame-options", "SAMEORIGIN")
+      |> put_resp_header("x-xss-protection", "1; mode=block")
+      |> put_resp_header("x-content-type-options", "nosniff")
     end)
   end
 end

--- a/lib/samly/router_util.ex
+++ b/lib/samly/router_util.ex
@@ -77,14 +77,14 @@ defmodule Samly.RouterUtil do
       resp_body = :esaml_binding.encode_http_post(idp_url, signed_xml_payload, relay_state)
 
       conn
-      |> Conn.put_resp_header("Content-Type", "text/html")
+      |> Conn.put_resp_header("content-type", "text/html")
       |> Conn.send_resp(200, resp_body)
     end
   end
 
   def redirect(conn, status_code, dest) do
     conn
-    |> Conn.put_resp_header("Location", dest)
+    |> Conn.put_resp_header("location", dest)
     |> Conn.send_resp(status_code, "")
     |> Conn.halt()
   end

--- a/lib/samly/sp_handler.ex
+++ b/lib/samly/sp_handler.ex
@@ -16,7 +16,7 @@ defmodule Samly.SPHandler do
     metadata = Helper.sp_metadata(sp)
 
     conn
-    |> put_resp_header("Content-Type", "text/xml")
+    |> put_resp_header("content-type", "text/xml")
     |> send_resp(200, metadata)
 
     # rescue


### PR DESCRIPTION
Updated calls to `put_resp_header` to use all-lower-case header names.

The Plug docs recommend using lower-case header names to avoid duplicates since the duplicate check in `put_resp_header` is case-sensitive. We had this problem, but the duplicate header names only caused trouble when we were using SSL. It gave us an `ERR_SPDY_PROTOCOL_ERROR` in Chrome. Each browser reacted differently, but none got a response. Down-casing the header names Samly adds eliminated the duplicates and fixed our problem.

Thanks for your work on this library!