### PR TITLE
Added config setting for nameid_format

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ config :samly, Samly.Provider,
       #signed_assertion_in_resp: true,
       #signed_envelopes_in_resp: true,
       #allow_idp_initiated_flow: false,
-      #allowed_target_urls: ["http://do-good.org"]
+      #allowed_target_urls: ["http://do-good.org"],
+      #nameid_format: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
     }
   ]
 ```
@@ -199,6 +200,7 @@ config :samly, Samly.Provider,
 | `signed_assertion_in_resp`, `signed_envelopes_in_resp` | _(optional)_ Default is `true`. When `true`, `Samly` expects the requests and responses from IdP to be signed. |
 | `allow_idp_initiated_flow` | _(optional)_ Default is `false`. IDP initiated SSO is allowed only when this is set to `true`. |
 | `allowed_target_urls` | _(optional)_ Default is `[]`. `Samly` uses this **only** when `allow_idp_initiated_flow` parameter is set to `true`. Make sure to set this to one or more exact URLs you want to allow (whitelist). The URL to redirect the user after completing the SSO flow is sent from IDP in auth response as `relay_state`. This `relay_state` target URL is matched against this URL list. Set the value to `nil` if you do not want this whitelist capability.  |
+| `nameid_format` | _(optional)_ Default is `"urn:oasis:names:tc:SAML:2.0:nameid-format:transient"`. When this is overridden, `Samly` will put the value in the `Format` attribute of the `NameIDPolicy` element of the login request. Value may be a string, a character list, or one of the following atoms: `email`, `x509`, `windows`, `krb`, `persistent`, `transient`.                                                                                                |
 
 #### Authenticated SAML Assertion State Store
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ config :samly, Samly.Provider,
       #signed_envelopes_in_resp: true,
       #allow_idp_initiated_flow: false,
       #allowed_target_urls: ["http://do-good.org"],
-      #nameid_format: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+      #nameid_format: :transient
     }
   ]
 ```
@@ -200,7 +200,7 @@ config :samly, Samly.Provider,
 | `signed_assertion_in_resp`, `signed_envelopes_in_resp` | _(optional)_ Default is `true`. When `true`, `Samly` expects the requests and responses from IdP to be signed. |
 | `allow_idp_initiated_flow` | _(optional)_ Default is `false`. IDP initiated SSO is allowed only when this is set to `true`. |
 | `allowed_target_urls` | _(optional)_ Default is `[]`. `Samly` uses this **only** when `allow_idp_initiated_flow` parameter is set to `true`. Make sure to set this to one or more exact URLs you want to allow (whitelist). The URL to redirect the user after completing the SSO flow is sent from IDP in auth response as `relay_state`. This `relay_state` target URL is matched against this URL list. Set the value to `nil` if you do not want this whitelist capability.  |
-| `nameid_format` | _(optional)_ Default is `"urn:oasis:names:tc:SAML:2.0:nameid-format:transient"`. When this is overridden, `Samly` will put the value in the `Format` attribute of the `NameIDPolicy` element of the login request. Value may be a string, a character list, or one of the following atoms: `email`, `x509`, `windows`, `krb`, `persistent`, `transient`.                                                                                                |
+| `nameid_format` | _(optional)_ When this is specified, `Samly` will put the value in the `Format` attribute of the `NameIDPolicy` element of the login request. Value may be a string, a character list, or one of the following atoms: `:email`, `:x509`, `:windows`, `:krb`, `:persistent`, `:transient`.                                                                                                |
 
 #### Authenticated SAML Assertion State Store
 

--- a/lib/samly/auth_handler.ex
+++ b/lib/samly/auth_handler.ex
@@ -59,7 +59,9 @@ defmodule Samly.AuthHandler do
 
       _ ->
         relay_state = State.gen_id()
-        {idp_signin_url, req_xml_frag} = Helper.gen_idp_signin_req(sp, idp_rec)
+
+        {idp_signin_url, req_xml_frag} =
+          Helper.gen_idp_signin_req(sp, idp_rec, Map.get(idp, :nameid_format))
 
         conn
         |> configure_session(renew: true)

--- a/lib/samly/helper.ex
+++ b/lib/samly/helper.ex
@@ -47,32 +47,12 @@ defmodule Samly.Helper do
     :xmerl.export([:esaml_sp.generate_metadata(sp)], :xmerl_xml)
   end
 
-  def gen_idp_signin_req(sp, idp_metadata, name_format) do
+  def gen_idp_signin_req(sp, idp_metadata, nameid_format) do
     idp_signin_url = Esaml.esaml_idp_metadata(idp_metadata, :login_location)
 
-    xml_frag =
-      :esaml_sp.generate_authn_request(idp_signin_url, sp, name_format_charlist(name_format))
+    xml_frag = :esaml_sp.generate_authn_request(idp_signin_url, sp, nameid_format)
 
     {idp_signin_url, xml_frag}
-  end
-
-  defp name_format_charlist(name_format) when is_list(name_format), do: name_format
-
-  defp name_format_charlist(name_format) when is_binary(name_format) do
-    name_format |> to_charlist()
-  end
-
-  defp name_format_charlist(nil), do: name_format_charlist(:transient)
-
-  defp name_format_charlist(name_format) do
-    case name_format do
-      :email -> 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
-      :x509 -> 'urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName'
-      :windows -> 'urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName'
-      :krb -> 'urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos'
-      :persistent -> 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
-      :transient -> 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
-    end
   end
 
   def gen_idp_signout_req(sp, idp_metadata, subject_rec, session_index) do

--- a/lib/samly/idp_data.ex
+++ b/lib/samly/idp_data.ex
@@ -100,6 +100,7 @@ defmodule Samly.IdpData do
     %IdpData{}
     |> save_idp_config(idp_config)
     |> load_metadata(idp_config)
+    |> set_nameid_format(idp_config)
     |> update_esaml_recs(service_providers, idp_config)
   end
 
@@ -160,8 +161,7 @@ defmodule Samly.IdpData do
 
   @spec cert_config_ok?(%IdpData{}, %SpData{}) :: boolean
   defp cert_config_ok?(%IdpData{} = idp_data, %SpData{} = sp_data) do
-    if (idp_data.sign_metadata ||
-          idp_data.sign_requests) &&
+    if (idp_data.sign_metadata || idp_data.sign_requests) &&
          (sp_data.cert == :undefined || sp_data.key == :undefined) do
       Logger.error("[Samly] SP cert or key missing - Skipping identity provider: #{idp_data.id}")
       false
@@ -192,6 +192,13 @@ defmodule Samly.IdpData do
 
     %IdpData{idp_data | allowed_target_urls: target_urls}
   end
+
+  @spec set_nameid_format(%IdpData{}, map()) :: %IdpData{}
+  defp set_nameid_format(%IdpData{} = idp_data, %{nameid_format: nameid_format}) do
+    %IdpData{idp_data | nameid_format: nameid_format}
+  end
+
+  defp set_nameid_format(%IdpData{} = idp_data, _opts_map), do: idp_data
 
   @spec set_boolean_attr(%IdpData{}, map(), atom()) :: %IdpData{}
   defp set_boolean_attr(%IdpData{} = idp_data, %{} = opts_map, attr_name)

--- a/test/samly_idp_data_test.exs
+++ b/test/samly_idp_data_test.exs
@@ -248,7 +248,7 @@ defmodule SamlyIdpDataTest do
 
   test "nameid-format-in-metadata-but-not-config-should-use-metadata", %{sps: sps} do
     %IdpData{} = idp_data = IdpData.load_provider(@idp_config1, sps)
-    assert idp_data.nameid_format == :transient
+    assert idp_data.nameid_format == 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
   end
 
   test "nameid-format-in-config-but-not-metadata-should-use-config", %{sps: sps} do
@@ -259,7 +259,7 @@ defmodule SamlyIdpDataTest do
       })
 
     %IdpData{} = idp_data = IdpData.load_provider(idp_config, sps)
-    assert idp_data.nameid_format == :email
+    assert idp_data.nameid_format == 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
   end
 
   test "nameid-format-in-metadata-and-config-should-use-config", %{sps: sps} do
@@ -269,7 +269,7 @@ defmodule SamlyIdpDataTest do
       })
 
     %IdpData{} = idp_data = IdpData.load_provider(idp_config, sps)
-    assert idp_data.nameid_format == :persistent
+    assert idp_data.nameid_format == 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
   end
 
   test "nameid-format-in-neither-metadata-nor-config-should-be-unknown", %{sps: sps} do

--- a/test/samly_idp_data_test.exs
+++ b/test/samly_idp_data_test.exs
@@ -245,4 +245,40 @@ defmodule SamlyIdpDataTest do
     %IdpData{} = idp_data = IdpData.load_provider(idp_config, sps)
     refute idp_data.valid?
   end
+
+  test "nameid-format-in-metadata-but-not-config-should-use-metadata", %{sps: sps} do
+    %IdpData{} = idp_data = IdpData.load_provider(@idp_config1, sps)
+    assert idp_data.nameid_format == :transient
+  end
+
+  test "nameid-format-in-config-but-not-metadata-should-use-config", %{sps: sps} do
+    idp_config =
+      Map.merge(@idp_config1, %{
+        metadata_file: "test/data/shibboleth_idp_metadata.xml",
+        nameid_format: :email
+      })
+
+    %IdpData{} = idp_data = IdpData.load_provider(idp_config, sps)
+    assert idp_data.nameid_format == :email
+  end
+
+  test "nameid-format-in-metadata-and-config-should-use-config", %{sps: sps} do
+    idp_config =
+      Map.merge(@idp_config1, %{
+        nameid_format: :persistent
+      })
+
+    %IdpData{} = idp_data = IdpData.load_provider(idp_config, sps)
+    assert idp_data.nameid_format == :persistent
+  end
+
+  test "nameid-format-in-neither-metadata-nor-config-should-be-unknown", %{sps: sps} do
+    idp_config =
+      Map.merge(@idp_config1, %{
+        metadata_file: "test/data/shibboleth_idp_metadata.xml"
+      })
+
+    %IdpData{} = idp_data = IdpData.load_provider(idp_config, sps)
+    assert idp_data.nameid_format == :unknown
+  end
 end


### PR DESCRIPTION
Added config setting for `nameid_format` and updated `README` with usage. When omitted, preserves current behavior of using `'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'`.