### PR TITLE
Allow federation metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ config :samly, Samly.Provider,
 | `sp_id` | _(mandatory)_ The service provider definition to be used with this Identity Provider definition |
 | `base_url` | _(optional)_ If missing `Samly` will use the current URL to derive this. It is better to define this in production deployment. |
 | `metadata_file` | _(mandatory)_ Path to the IdP metadata XML file obtained from the Identity Provider. |
+| `entity_id` | _(optional)_ In case metadata file contains federation definition (root element is `EntitiesDescriptor`) this field is necessary. Based on that samly will extract appropriate idp element.
 | `pre_session_create_pipeline` | _(optional)_ Check the customization section. |
 | `use_redirect_for_req` | _(optional)_ Default is `false`. When this is `false`, `Samly` will POST to the IdP SAML endpoints. |
 | `sign_requests`, `sign_metadata` | _(optional)_ Default is `true`. |

--- a/lib/samly/idp_data.ex
+++ b/lib/samly/idp_data.ex
@@ -268,12 +268,11 @@ defmodule Samly.IdpData do
 
     md_xml = SweetXml.parse(metadata_xml, xml_opts)
 
-    entityID = case opts[:entity_id] do
-      nil ->
-        get_entity_id(md_xml)
-      e ->
-        e
-    end
+    entityID =
+      case federation_metadata?(opts) do
+        false -> get_entity_id(md_xml)
+        true -> opts[:entity_id]
+      end
 
     entity_md_xml = get_entity_descriptor(md_xml, entityID)
 
@@ -300,6 +299,8 @@ defmodule Samly.IdpData do
           }}
     end
   end
+
+  defp federation_metadata?(opts), do: opts[:entity_id] != nil
 
   # @spec to_esaml_idp_metadata(IdpData.t(), map()) :: :esaml_idp_metadata
   defp to_esaml_idp_metadata(%IdpData{} = idp_data, %{} = idp_config) do

--- a/lib/samly/idp_data.ex
+++ b/lib/samly/idp_data.ex
@@ -451,7 +451,7 @@ defmodule Samly.IdpData do
 
   @spec get_entity_descriptor(:xmlElement, entityID :: binary()) :: :xmlElement | nil
   defp get_entity_descriptor(md_xml, entityID) do
-    selector = entity_by_id_selector(entityID)
+    selector = entity_by_id_selector(entityID) |> add_ns()
     try do
       SweetXml.xpath(md_xml, selector)
     rescue

--- a/lib/samly/idp_data.ex
+++ b/lib/samly/idp_data.ex
@@ -73,15 +73,21 @@ defmodule Samly.IdpData do
   @post "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
 
   @entity_id_selector ~x"//#{@entdesc}/@entityID"sl
-  @nameid_format_selector ~x"//#{@entdesc}/#{@idpdesc}/#{@nameid}/text()"s
   @req_signed_selector ~x"//#{@entdesc}/#{@idpdesc}/@#{@signedreq}"s
-  @sso_redirect_url_selector ~x"//#{@entdesc}/#{@idpdesc}/#{@ssos}[@Binding = '#{@redirect}']/@Location"s
-  @sso_post_url_selector ~x"//#{@entdesc}/#{@idpdesc}/#{@ssos}[@Binding = '#{@post}']/@Location"s
-  @slo_redirect_url_selector ~x"//#{@entdesc}/#{@idpdesc}/#{@slos}[@Binding = '#{@redirect}']/@Location"s
-  @slo_post_url_selector ~x"//#{@entdesc}/#{@idpdesc}/#{@slos}[@Binding = '#{@post}']/@Location"s
   @signing_keys_selector ~x"//#{@entdesc}/#{@idpdesc}/#{@keydesc}[@use != 'encryption']"l
   @enc_keys_selector ~x"//#{@entdesc}/#{@idpdesc}/#{@keydesc}[@use = 'encryption']"l
+
+
+  # These functions work on EntityDescriptor element
+  @sso_redirect_url_selector ~x"/#{@entdesc}/#{@idpdesc}/#{@ssos}[@Binding = '#{@redirect}']/@Location"s
+  @sso_post_url_selector ~x"/#{@entdesc}/#{@idpdesc}/#{@ssos}[@Binding = '#{@post}']/@Location"s
+  @slo_redirect_url_selector ~x"/#{@entdesc}/#{@idpdesc}/#{@slos}[@Binding = '#{@redirect}']/@Location"s
+  @slo_post_url_selector ~x"/#{@entdesc}/#{@idpdesc}/#{@slos}[@Binding = '#{@post}']/@Location"s
+  @nameid_format_selector ~x"/#{@entdesc}/#{@idpdesc}/#{@nameid}/text()"s # TODO How to deal with multiple nameid formats?
+  @signing_keys_in_idp_selector ~x"./#{@idpdesc}/#{@keydesc}[@use != 'encryption']"l
   @cert_selector ~x"./ds:KeyInfo/ds:X509Data/ds:X509Certificate/text()"s
+
+  defp entity_by_id_selector(id), do: ~x"/#{@entsdesc}/#{@entdesc}[@entityID = '#{id}'][1]"
 
   @type id :: binary()
 
@@ -121,9 +127,9 @@ defmodule Samly.IdpData do
   end
 
   @spec load_metadata(%IdpData{}, map()) :: %IdpData{}
-  defp load_metadata(idp_data, _opts_map) do
+  defp load_metadata(idp_data, opts_map) do
     with {:reading, {:ok, raw_xml}} <- {:reading, File.read(idp_data.metadata_file)},
-         {:parsing, {:ok, idp_data}} <- {:parsing, from_xml(raw_xml, idp_data)} do
+         {:parsing, {:ok, idp_data}} <- {:parsing, from_xml(raw_xml, idp_data, opts_map)} do
       idp_data
     else
       {:reading, {:error, reason}} ->
@@ -251,8 +257,8 @@ defmodule Samly.IdpData do
     if is_boolean(v), do: Map.put(idp_data, attr_name, v), else: idp_data
   end
 
-  @spec from_xml(binary, %IdpData{}) :: {:ok, %IdpData{}}
-  def from_xml(metadata_xml, idp_data) when is_binary(metadata_xml) do
+  @spec from_xml(binary, %IdpData{}, %{}) :: {:ok, %IdpData{}}
+  def from_xml(metadata_xml, idp_data, opts) when is_binary(metadata_xml) do
     xml_opts = [
       space: :normalize,
       namespace_conformant: true,
@@ -261,21 +267,38 @@ defmodule Samly.IdpData do
     ]
 
     md_xml = SweetXml.parse(metadata_xml, xml_opts)
-    signing_certs = get_signing_certs(md_xml)
 
-    {:ok,
-     %IdpData{
-       idp_data
-       | entity_id: get_entity_id(md_xml),
-         signed_requests: get_req_signed(md_xml),
-         certs: signing_certs,
-         fingerprints: idp_cert_fingerprints(signing_certs),
-         sso_redirect_url: get_sso_redirect_url(md_xml),
-         sso_post_url: get_sso_post_url(md_xml),
-         slo_redirect_url: get_slo_redirect_url(md_xml),
-         slo_post_url: get_slo_post_url(md_xml),
-         nameid_format: get_nameid_format(md_xml)
-     }}
+    entityID = case opts[:entity_id] do
+      nil ->
+        get_entity_id(md_xml)
+      e ->
+        e
+    end
+
+    entity_md_xml = get_entity_descriptor(md_xml, entityID)
+
+    
+
+    case entity_md_xml do
+      nil ->
+        {:error, :entity_not_found}
+      _ ->
+        signing_certs = get_signing_certs_in_idp(entity_md_xml)
+
+        {:ok,
+          %IdpData{
+            idp_data
+            | entity_id: entityID,
+            signed_requests: get_req_signed(md_xml),
+            certs: signing_certs,
+            fingerprints: idp_cert_fingerprints(signing_certs),
+            sso_redirect_url: get_sso_redirect_url(entity_md_xml),
+            sso_post_url: get_sso_post_url(entity_md_xml),
+            slo_redirect_url: get_slo_redirect_url(entity_md_xml),
+            slo_post_url: get_slo_post_url(entity_md_xml),
+            nameid_format: get_nameid_format(entity_md_xml)
+          }}
+    end
   end
 
   # @spec to_esaml_idp_metadata(IdpData.t(), map()) :: :esaml_idp_metadata
@@ -357,7 +380,7 @@ defmodule Samly.IdpData do
     )
   end
 
-  @spec get_entity_id(:xmlElement) :: binary()
+ @spec get_entity_id(:xmlElement) :: binary()
   def get_entity_id(md_elem) do
     md_elem |> xpath(@entity_id_selector |> add_ns()) |> hd() |> String.trim()
   end
@@ -373,11 +396,10 @@ defmodule Samly.IdpData do
   @spec get_req_signed(:xmlElement) :: binary()
   def get_req_signed(md_elem), do: get_data(md_elem, @req_signed_selector)
 
-  @spec get_signing_certs(:xmlElement) :: certs()
-  def get_signing_certs(md_elem), do: get_certs(md_elem, @signing_keys_selector)
+  #@spec get_signing_certs(:xmlElement) :: certs()
+  #def get_signing_certs(md_elem), do: get_certs(md_elem, signing_keys_selector())
 
-  @spec get_enc_certs(:xmlElement) :: certs()
-  def get_enc_certs(md_elem), do: get_certs(md_elem, @enc_keys_selector)
+  def get_signing_certs_in_idp(md_elem), do: get_certs(md_elem, @signing_keys_in_idp_selector)
 
   @spec get_certs(:xmlElement, %SweetXpath{}) :: certs()
   defp get_certs(md_elem, key_selector) do
@@ -425,4 +447,15 @@ defmodule Samly.IdpData do
     |> SweetXml.add_namespace("md", "urn:oasis:names:tc:SAML:2.0:metadata")
     |> SweetXml.add_namespace("ds", "http://www.w3.org/2000/09/xmldsig#")
   end
-end
+
+  @spec get_entity_descriptor(:xmlElement, entityID :: binary()) :: :xmlElement | nil
+  defp get_entity_descriptor(md_xml, entityID) do
+    selector = entity_by_id_selector(entityID)
+    try do
+      SweetXml.xpath(md_xml, selector)
+    rescue
+      _ -> {:error, :entity_not_found}
+    end
+  end
+
+end 

--- a/lib/samly/idp_data.ex
+++ b/lib/samly/idp_data.ex
@@ -83,7 +83,7 @@ defmodule Samly.IdpData do
   @sso_post_url_selector ~x"/#{@entdesc}/#{@idpdesc}/#{@ssos}[@Binding = '#{@post}']/@Location"s
   @slo_redirect_url_selector ~x"/#{@entdesc}/#{@idpdesc}/#{@slos}[@Binding = '#{@redirect}']/@Location"s
   @slo_post_url_selector ~x"/#{@entdesc}/#{@idpdesc}/#{@slos}[@Binding = '#{@post}']/@Location"s
-  @nameid_format_selector ~x"/#{@entdesc}/#{@idpdesc}/#{@nameid}/text()"s # TODO How to deal with multiple nameid formats?
+  @nameid_format_selector ~x"/#{@entdesc}/#{@idpdesc}/#{@nameid}/text()[1]"s # TODO How to deal with multiple nameid formats?
   @signing_keys_in_idp_selector ~x"./#{@idpdesc}/#{@keydesc}[@use != 'encryption']"l
   @cert_selector ~x"./ds:KeyInfo/ds:X509Data/ds:X509Certificate/text()"s
 

--- a/test/data/idp_federation_metadata.xml
+++ b/test/data/idp_federation_metadata.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" xmlns:shibmd="urn:mace:shibboleth:metadata:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="AAITest-20190613090159" Name="urn:mace:switch.ch:aaitest" validUntil="2019-06-18T07:01:59Z" xsi:schemaLocation="urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"><ds:Signature>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><EntitiesDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" xmlns:shibmd="urn:mace:shibboleth:metadata:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="AAITest-20190613090159" Name="urn:mace:switch.ch:aaitest" validUntil="2019-06-18T07:01:59Z" xsi:schemaLocation="urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"><ds:Signature>
 <ds:SignedInfo>
 <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
 <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
@@ -136,7 +136,7 @@ kTrorHQ4/wGoDIpifcLse8Rj3PZdMQ==
     <!-- Identity Provider Metadata -->
 
 	<!-- AAI Demo Home Organisation -->
-	<md:EntityDescriptor entityID="https://aai-demo-idp.switch.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://aai-demo-idp.switch.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -150,9 +150,9 @@ kTrorHQ4/wGoDIpifcLse8Rj3PZdMQ==
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">aai-demo-idp.switch.ch</shibmd:Scope>
+				<shibScope regexp="false">aai-demo-idp.switch.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="de">AAI Demo Home Organisation</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="en">AAI Demo Home Organisation</mdui:DisplayName>
@@ -169,7 +169,7 @@ kTrorHQ4/wGoDIpifcLse8Rj3PZdMQ==
 					<mdui:DomainHint>example.org</mdui:DomainHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -194,21 +194,21 @@ JLuwKIc2AqbiZQxOuWf/+la8SBstg/xzsU0cLX43tD6b5AZajCylvU1RaxEkFBRb
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-demo-idp.switch.ch:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-demo-idp.switch.ch:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-demo-idp.switch.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-demo-idp.switch.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-demo-idp.switch.ch/idp/profile/SAML2/POST/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-demo-idp.switch.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-demo-idp.switch.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-demo-idp.switch.ch/idp/profile/SAML2/POST/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">aai-demo-idp.switch.ch</shibmd:Scope>
+				<shibScope regexp="false">aai-demo-idp.switch.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -233,12 +233,12 @@ JLuwKIc2AqbiZQxOuWf/+la8SBstg/xzsU0cLX43tD6b5AZajCylvU1RaxEkFBRb
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-demo-idp.switch.ch:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-demo-idp.switch.ch:8443/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">aai-demo-idp.switch.ch</OrganizationName>
@@ -247,10 +247,10 @@ JLuwKIc2AqbiZQxOuWf/+la8SBstg/xzsU0cLX43tD6b5AZajCylvU1RaxEkFBRb
 			<OrganizationURL xml:lang="de">http://www.aai-demo-idp.switch.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="en">http://www.aai-demo-idp.switch.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- ETH Zurich (BI test) -->
-	<md:EntityDescriptor entityID="https://aai-logon-bi-test.ethz.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://aai-logon-bi-test.ethz.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -264,9 +264,9 @@ JLuwKIc2AqbiZQxOuWf/+la8SBstg/xzsU0cLX43tD6b5AZajCylvU1RaxEkFBRb
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor errorURL="http://www.id.ethz.ch/servicedesk" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor errorURL="http://www.id.ethz.ch/servicedesk" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">aai-logon-bi-test.ethz.ch</shibmd:Scope>
+				<shibScope regexp="false">aai-logon-bi-test.ethz.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="de">ETH Zürich (BI test)</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="en">ETH Zurich (BI test)</mdui:DisplayName>
@@ -283,7 +283,7 @@ JLuwKIc2AqbiZQxOuWf/+la8SBstg/xzsU0cLX43tD6b5AZajCylvU1RaxEkFBRb
 					<mdui:GeolocationHint>geo:46.022244,8.916146</mdui:GeolocationHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -326,22 +326,22 @@ Nc+ngn1OAVc=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">aai-logon-bi-test.ethz.ch</shibmd:Scope>
+				<shibScope regexp="false">aai-logon-bi-test.ethz.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -384,12 +384,12 @@ Nc+ngn1OAVc=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">aai-logon-bi-test.ethz.ch</OrganizationName>
@@ -398,10 +398,10 @@ Nc+ngn1OAVc=
 			<OrganizationURL xml:lang="de">http://www.aai-logon-bi-test.ethz.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="en">http://www.aai-logon-bi-test.ethz.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- HES-SO Test IdP -->
-	<md:EntityDescriptor entityID="https://aai-logon-test.hes-so.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://aai-logon-test.hes-so.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -415,9 +415,9 @@ Nc+ngn1OAVc=
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">aai-logon-test.hes-so.ch</shibmd:Scope>
+				<shibScope regexp="false">aai-logon-test.hes-so.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">HES-SO Test IdP</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="fr">HES-SO Test IdP</mdui:DisplayName>
@@ -428,7 +428,7 @@ Nc+ngn1OAVc=
 					<mdui:DomainHint>aai-logon-test.hes-so.ch</mdui:DomainHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -453,22 +453,22 @@ yIjEdB67LkSbGlrCa0glLGKZFnAqEXxgKGgFLOZS0dZhGf0byWcVLjLtfoM8ntyN
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon-test.hes-so.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon-test.hes-so.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">aai-logon-test.hes-so.ch</shibmd:Scope>
+				<shibScope regexp="false">aai-logon-test.hes-so.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -493,12 +493,12 @@ yIjEdB67LkSbGlrCa0glLGKZFnAqEXxgKGgFLOZS0dZhGf0byWcVLjLtfoM8ntyN
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">aai-logon-test.hes-so.ch</OrganizationName>
@@ -507,10 +507,10 @@ yIjEdB67LkSbGlrCa0glLGKZFnAqEXxgKGgFLOZS0dZhGf0byWcVLjLtfoM8ntyN
 			<OrganizationURL xml:lang="en">http://www.aai-logon-test.hes-so.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="fr">http://www.aai-logon-test.hes-so.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- HUG Idp TEST -->
-	<md:EntityDescriptor entityID="https://aai-test.hcuge.ch/idp">
+	<EntityDescriptor entityID="https://aai-test.hcuge.ch/idp">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -524,9 +524,9 @@ yIjEdB67LkSbGlrCa0glLGKZFnAqEXxgKGgFLOZS0dZhGf0byWcVLjLtfoM8ntyN
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">aai-test.hcuge.ch</shibmd:Scope>
+				<shibScope regexp="false">aai-test.hcuge.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">HUG Test IdP</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="fr">HUG Idp TEST</mdui:DisplayName>
@@ -539,7 +539,7 @@ yIjEdB67LkSbGlrCa0glLGKZFnAqEXxgKGgFLOZS0dZhGf0byWcVLjLtfoM8ntyN
 					<mdui:GeolocationHint>geo:46.19383,6.14882</mdui:GeolocationHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -584,15 +584,15 @@ a1oLA25R+SSx9x3c3AwNzRByoW7HfR7SaINGhlv8z/xiFDQm53x0IOCWA1EeKozQ
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-			<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-test.hcuge.ch/saml/idp/profile/redirect/sls"/>
-			<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-test.hcuge.ch/saml/idp/profile/post/sls"/>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-test.hcuge.ch/saml/idp/profile/redirectorpost/sso"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-test.hcuge.ch/saml/idp/profile/redirectorpost/sso"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-test.hcuge.ch/saml/idp/profile/ecp/sso"/>
-		</md:IDPSSODescriptor>
+			</KeyDescriptor>
+			<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-test.hcuge.ch/saml/idp/profile/redirect/sls"/>
+			<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-test.hcuge.ch/saml/idp/profile/post/sls"/>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-test.hcuge.ch/saml/idp/profile/redirectorpost/sso"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-test.hcuge.ch/saml/idp/profile/redirectorpost/sso"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-test.hcuge.ch/saml/idp/profile/ecp/sso"/>
+		</IDPSSODescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">aai-test.hcuge.ch</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">HUG Test IdP</OrganizationDisplayName>
@@ -600,10 +600,10 @@ a1oLA25R+SSx9x3c3AwNzRByoW7HfR7SaINGhlv8z/xiFDQm53x0IOCWA1EeKozQ
 			<OrganizationURL xml:lang="en">http://www.aai-test.hcuge.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="fr">http://www.aai-test.hcuge.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- FHNW-DEV - Fachhochschule Nordwestschweiz -->
-	<md:EntityDescriptor entityID="https://aai-logon.dev.fhnw.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://aai-logon.dev.fhnw.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -617,9 +617,9 @@ a1oLA25R+SSx9x3c3AwNzRByoW7HfR7SaINGhlv8z/xiFDQm53x0IOCWA1EeKozQ
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">dev.fhnw.ch</shibmd:Scope>
+				<shibScope regexp="false">dev.fhnw.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">FHNW-DEV - Fachhochschule Nordwestschweiz</mdui:DisplayName>
 					<mdui:Description xml:lang="en">FHNW-DEV IdP of: dev.fhnw.ch</mdui:Description>
@@ -627,7 +627,7 @@ a1oLA25R+SSx9x3c3AwNzRByoW7HfR7SaINGhlv8z/xiFDQm53x0IOCWA1EeKozQ
 				<mdui:DiscoHints>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -652,21 +652,21 @@ CG9Wz9KLfaxssPHaavd96MVteM8=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon.dev.fhnw.ch/shibboleth-idp/Artifact" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon.dev.fhnw.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon.dev.fhnw.ch/shibboleth-idp/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon.dev.fhnw.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon.dev.fhnw.ch/idp/profile/SAML2/POST/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon.dev.fhnw.ch/shibboleth-idp/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon.dev.fhnw.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon.dev.fhnw.ch/idp/profile/SAML2/POST/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">dev.fhnw.ch</shibmd:Scope>
+				<shibScope regexp="false">dev.fhnw.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -691,22 +691,22 @@ CG9Wz9KLfaxssPHaavd96MVteM8=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon.dev.fhnw.ch/shibboleth-idp/AA"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon.dev.fhnw.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">dev.fhnw.ch</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">FHNW-DEV - Fachhochschule Nordwestschweiz</OrganizationDisplayName>
 			<OrganizationURL xml:lang="en">http://www.dev.fhnw.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- Bootstrapped Home Organization e-xpertsolutions.com -->
-	<md:EntityDescriptor entityID="https://fedauth.e-xpertsolutions.com">
+	<EntityDescriptor entityID="https://fedauth.e-xpertsolutions.com">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -720,9 +720,9 @@ CG9Wz9KLfaxssPHaavd96MVteM8=
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">e-xpertsolutions.com</shibmd:Scope>
+				<shibScope regexp="false">e-xpertsolutions.com</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">Bootstrapped Home Organization e-xpertsolutions.com</mdui:DisplayName>
 					<mdui:Description xml:lang="en">Bootstrapped IdP of: e-xpertsolutions.com</mdui:Description>
@@ -730,7 +730,7 @@ CG9Wz9KLfaxssPHaavd96MVteM8=
 				<mdui:DiscoHints>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -760,20 +760,20 @@ JNnDUuUfZAZMhvke/Df73gMbaQ3zQmwe9UhYggnwutBDf6PlDQ==
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://fedauth.e-xpertsolutions.com/saml/idp/profile/redirectorpost/sso"/>
-		</md:IDPSSODescriptor>
+			</KeyDescriptor>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://fedauth.e-xpertsolutions.com/saml/idp/profile/redirectorpost/sso"/>
+		</IDPSSODescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">e-xpertsolutions.com</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">Bootstrapped Home Organization e-xpertsolutions.com</OrganizationDisplayName>
 			<OrganizationURL xml:lang="en">http://www.e-xpertsolutions.com/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- Graduate Institute - Test IdP -->
-	<md:EntityDescriptor entityID="https://idp-dev.graduateinstitute.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://idp-dev.graduateinstitute.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -790,9 +790,9 @@ JNnDUuUfZAZMhvke/Df73gMbaQ3zQmwe9UhYggnwutBDf6PlDQ==
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">graduateinstitute.ch</shibmd:Scope>
+				<shibScope regexp="false">graduateinstitute.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">Graduate Institute - Test IdP</mdui:DisplayName>
 					<mdui:Description xml:lang="en">Test IdP of the Graduate Institute of International and Development Studies</mdui:Description>
@@ -801,7 +801,7 @@ JNnDUuUfZAZMhvke/Df73gMbaQ3zQmwe9UhYggnwutBDf6PlDQ==
 					<mdui:GeolocationHint>geo:46.22097,6.14375</mdui:GeolocationHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -826,19 +826,19 @@ pa1lQomsWHiCP19hC2za2mWHu/WdtcLLphdA3t2K6+dmR9WX6O8YzcSyk6gLtZF9
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="1"/>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">graduateinstitute.ch</shibmd:Scope>
+				<shibScope regexp="false">graduateinstitute.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -863,26 +863,26 @@ pa1lQomsWHiCP19hC2za2mWHu/WdtcLLphdA3t2K6+dmR9WX6O8YzcSyk6gLtZF9
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">graduateinstitute.ch</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">Graduate Institute - Test IdP</OrganizationDisplayName>
 			<OrganizationURL xml:lang="en">http://www.graduateinstitute.ch/</OrganizationURL>
 		</Organization>                
-		<ContactPerson xmlns:remd="http://refeds.org/metadata" contactType="other" remd:contactType="http://refeds.org/metadata/contactType/security">
+		<ContactPerson xmlns:remd="http://refeds.org/metadata" contactType="other" recontactType="http://refeds.org/metadata/contactType/security">
 			<GivenName>Wilfred</GivenName>
 			<SurName>Gander</SurName>
 			<EmailAddress>mailto:wilfred.gander@graduateinstitute.ch</EmailAddress>
 			
 		</ContactPerson>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- HCUGE Proxy (testing) -->
-	<md:EntityDescriptor entityID="https://hug-proxy.switch.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://hug-proxy.switch.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -896,9 +896,9 @@ pa1lQomsWHiCP19hC2za2mWHu/WdtcLLphdA3t2K6+dmR9WX6O8YzcSyk6gLtZF9
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor errorURL="https://www.switch.ch/aai" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<IDPSSODescriptor errorURL="https://www.switch.ch/aai" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">hcuge.ch</shibmd:Scope>
+				<shibScope regexp="false">hcuge.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">HCUGE Proxy (testing)</mdui:DisplayName>
 					<mdui:Description xml:lang="en">HCUGE Proxy (testing)</mdui:Description>
@@ -906,7 +906,7 @@ pa1lQomsWHiCP19hC2za2mWHu/WdtcLLphdA3t2K6+dmR9WX6O8YzcSyk6gLtZF9
 				<mdui:DiscoHints>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -936,20 +936,20 @@ kGvnsME0QPNqtMrddUyoYZY0rDZxsMIZysGZMA==
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://hug-proxy.switch.ch/idp/profile/SAML2/POST/SSO"/>
-		</md:IDPSSODescriptor>
+			</KeyDescriptor>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://hug-proxy.switch.ch/idp/profile/SAML2/POST/SSO"/>
+		</IDPSSODescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">hcuge.ch</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">HCUGE Proxy (testing)</OrganizationDisplayName>
 			<OrganizationURL xml:lang="en">http://www.hcuge.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- HEP Vaud - TEST - Haute école pédagogique du canton de Vaud -->
-	<md:EntityDescriptor entityID="https://aai-login-int.hepl.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://aai-login-int.hepl.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -963,9 +963,9 @@ kGvnsME0QPNqtMrddUyoYZY0rDZxsMIZysGZMA==
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">hepl.ch</shibmd:Scope>
+				<shibScope regexp="false">hepl.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">HEP Vaud - TEST - Haute école pédagogique du canton de Vaud</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="fr">HEP Vaud - TEST - Haute école pédagogique du canton de Vaud</mdui:DisplayName>
@@ -979,7 +979,7 @@ kGvnsME0QPNqtMrddUyoYZY0rDZxsMIZysGZMA==
 					<mdui:GeolocationHint>geo:46.5128606,6.621523</mdui:GeolocationHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1004,8 +1004,8 @@ q86sgQ1la6oiGuWbDpjrCofMaqgU0fGSZ5A7uz1WHwv5XmxGiqUFrGRGJWiuKL8z
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-			<md:KeyDescriptor use="signing">
+			</KeyDescriptor>
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1050,8 +1050,8 @@ nT2DecWFfixBKpGwMp0OfspUijtXEFbEHmVjYXavlIIm
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-			<md:KeyDescriptor use="signing">
+			</KeyDescriptor>
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1076,17 +1076,17 @@ LS8+eshenGJr2pxeZJcAM9xqyU8=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-login-int.hepl.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-login-int.hepl.ch/idp/profile/SAML2/POST/SSO"/>
-		</md:IDPSSODescriptor>
+			</KeyDescriptor>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-login-int.hepl.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-login-int.hepl.ch/idp/profile/SAML2/POST/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">hepl.ch</shibmd:Scope>
+				<shibScope regexp="false">hepl.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1111,8 +1111,8 @@ q86sgQ1la6oiGuWbDpjrCofMaqgU0fGSZ5A7uz1WHwv5XmxGiqUFrGRGJWiuKL8z
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-			<md:KeyDescriptor use="signing">
+			</KeyDescriptor>
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1157,8 +1157,8 @@ nT2DecWFfixBKpGwMp0OfspUijtXEFbEHmVjYXavlIIm
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-			<md:KeyDescriptor use="signing">
+			</KeyDescriptor>
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1183,10 +1183,10 @@ LS8+eshenGJr2pxeZJcAM9xqyU8=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-login-int.hepl.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">hepl.ch</OrganizationName>
@@ -1195,10 +1195,10 @@ LS8+eshenGJr2pxeZJcAM9xqyU8=
 			<OrganizationURL xml:lang="en">http://www.hepl.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="fr">http://www.hepl.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- HFTM Test Identity Provider -->
-	<md:EntityDescriptor entityID="https://aai.hftm.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://aai.hftm.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -1212,9 +1212,9 @@ LS8+eshenGJr2pxeZJcAM9xqyU8=
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">hftm.ch</shibmd:Scope>
+				<shibScope regexp="false">hftm.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">HFTM Test Identity Provider</mdui:DisplayName>
 					<mdui:Description xml:lang="en">Bootstrapped IdP of: hftm.ch</mdui:Description>
@@ -1222,7 +1222,7 @@ LS8+eshenGJr2pxeZJcAM9xqyU8=
 				<mdui:DiscoHints>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1246,20 +1246,20 @@ g8NmxpkGQDpxXle7HwRW7Lw9WWWOQvuVOYLE
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai.hftm.ch/idp/profile/SAML2/POST/SSO"/>
-		</md:IDPSSODescriptor>
+			</KeyDescriptor>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai.hftm.ch/idp/profile/SAML2/POST/SSO"/>
+		</IDPSSODescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">hftm.ch</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">HFTM Test Identity Provider</OrganizationDisplayName>
 			<OrganizationURL xml:lang="en">http://www.hftm.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- HSLU - Hochschule Luzern (Test IdP) -->
-	<md:EntityDescriptor entityID="https://idp.hslu-lab.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://idp.hslu-lab.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -1273,9 +1273,9 @@ g8NmxpkGQDpxXle7HwRW7Lw9WWWOQvuVOYLE
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor errorURL="http://hotline.hslu.ch/" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<IDPSSODescriptor errorURL="http://hotline.hslu.ch/" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">hslu.ch</shibmd:Scope>
+				<shibScope regexp="false">hslu.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="de">HSLU - Hochschule Luzern (Test IdP)</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="en">HSLU - Lucerne University of Applied Sciences and Arts (Test IdP)</mdui:DisplayName>
@@ -1331,7 +1331,7 @@ g8NmxpkGQDpxXle7HwRW7Lw9WWWOQvuVOYLE
 					<mdui:GeolocationHint>geo:47.054246,8.295853</mdui:GeolocationHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1355,18 +1355,18 @@ yhtEPzc4dxhh5e6U3pfMqkFkAiEKsg6TnGbEVQuDMy5922C83RMUqT4z3kA=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp.hslu-lab.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="1"/>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.hslu-lab.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.hslu-lab.ch/idp/profile/SAML2/POST/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.hslu-lab.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.hslu-lab.ch/idp/profile/SAML2/POST/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">hslu.ch</shibmd:Scope>
+				<shibScope regexp="false">hslu.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1390,10 +1390,10 @@ yhtEPzc4dxhh5e6U3pfMqkFkAiEKsg6TnGbEVQuDMy5922C83RMUqT4z3kA=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp.hslu-lab.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">hslu.ch</OrganizationName>
@@ -1402,10 +1402,10 @@ yhtEPzc4dxhh5e6U3pfMqkFkAiEKsg6TnGbEVQuDMy5922C83RMUqT4z3kA=
 			<OrganizationURL xml:lang="de">http://www.hslu.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="en">http://www.hslu.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- HSR - Hochschule für Technik Rapperswil -->
-	<md:EntityDescriptor entityID="https://aai.hsr.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://aai.hsr.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -1419,9 +1419,9 @@ yhtEPzc4dxhh5e6U3pfMqkFkAiEKsg6TnGbEVQuDMy5922C83RMUqT4z3kA=
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">hsr.ch</shibmd:Scope>
+				<shibScope regexp="false">hsr.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">HSR - Hochschule für Technik Rapperswil</mdui:DisplayName>
 					<mdui:Description xml:lang="en">University of Applied Sciences Rapperswil (Test)</mdui:Description>
@@ -1429,7 +1429,7 @@ yhtEPzc4dxhh5e6U3pfMqkFkAiEKsg6TnGbEVQuDMy5922C83RMUqT4z3kA=
 				<mdui:DiscoHints>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1453,20 +1453,20 @@ jy1NpjCN4pndPueRmR7J9VMMN1ARCpsJ
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai.hsr.ch/idp/profile/SAML2/POST/SSO"/>
-		</md:IDPSSODescriptor>
+			</KeyDescriptor>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai.hsr.ch/idp/profile/SAML2/POST/SSO"/>
+		</IDPSSODescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">hsr.ch</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">HSR - Hochschule für Technik Rapperswil</OrganizationDisplayName>
 			<OrganizationURL xml:lang="en">http://www.hsr.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- University of Geneva Lab Identity Provider -->
-	<md:EntityDescriptor entityID="https://idp-lab.unige.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://idp-lab.unige.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -1480,9 +1480,9 @@ jy1NpjCN4pndPueRmR7J9VMMN1ARCpsJ
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">idp-lab.unige.ch</shibmd:Scope>
+				<shibScope regexp="false">idp-lab.unige.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">University of Geneva Lab Identity Provider</mdui:DisplayName>
 					<mdui:Description xml:lang="en">University of Geneva Lab Identity Provider</mdui:Description>
@@ -1491,7 +1491,7 @@ jy1NpjCN4pndPueRmR7J9VMMN1ARCpsJ
 					<mdui:DomainHint>idp-lab.unige.ch</mdui:DomainHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1515,18 +1515,18 @@ ifJgPU+WUNfbazu78ifV63eAtUl+nBkhi5gMinY7oXtD0vK69FnXB2oZJHp3o5k=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp-lab.unige.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp-lab.unige.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-lab.unige.ch/idp/profile/SAML2/SOAP/ECP"/>
-		</md:IDPSSODescriptor>
+			</KeyDescriptor>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp-lab.unige.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp-lab.unige.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-lab.unige.ch/idp/profile/SAML2/SOAP/ECP"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">idp-lab.unige.ch</shibmd:Scope>
+				<shibScope regexp="false">idp-lab.unige.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1550,20 +1550,20 @@ ifJgPU+WUNfbazu78ifV63eAtUl+nBkhi5gMinY7oXtD0vK69FnXB2oZJHp3o5k=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-lab.unige.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">idp-lab.unige.ch</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">University of Geneva Lab Identity Provider</OrganizationDisplayName>
 			<OrganizationURL xml:lang="en">http://www.idp-lab.unige.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- University of Geneva Test Identity Provider -->
-	<md:EntityDescriptor entityID="https://idp-test.unige.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://idp-test.unige.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -1577,9 +1577,9 @@ ifJgPU+WUNfbazu78ifV63eAtUl+nBkhi5gMinY7oXtD0vK69FnXB2oZJHp3o5k=
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor errorURL="http://www.unige.ch/dinf/ntic/aai/errors/error-origin.php" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor errorURL="http://www.unige.ch/dinf/ntic/aai/errors/error-origin.php" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">idp-test.unige.ch</shibmd:Scope>
+				<shibScope regexp="false">idp-test.unige.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">University of Geneva Test Identity Provider</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="fr">Test IdP Université de Genève</mdui:DisplayName>
@@ -1590,7 +1590,7 @@ ifJgPU+WUNfbazu78ifV63eAtUl+nBkhi5gMinY7oXtD0vK69FnXB2oZJHp3o5k=
 					<mdui:DomainHint>idp-test.unige.ch</mdui:DomainHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1615,23 +1615,23 @@ Ofim
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://idp-test.unige.ch/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-test.unige.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://idp-test.unige.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp-test.unige.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp-test.unige.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://idp-test.unige.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-lab.unige.ch/idp/profile/SAML2/SOAP/ECP"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://idp-test.unige.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp-test.unige.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp-test.unige.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://idp-test.unige.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-lab.unige.ch/idp/profile/SAML2/SOAP/ECP"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">idp-test.unige.ch</shibmd:Scope>
+				<shibScope regexp="false">idp-test.unige.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1656,12 +1656,12 @@ Ofim
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://idp-test.unige.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-test.unige.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">idp-test.unige.ch</OrganizationName>
@@ -1670,13 +1670,13 @@ Ofim
 			<OrganizationURL xml:lang="en">http://www.idp-test.unige.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="fr">http://www.idp-test.unige.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- libraries.ch Test -->
-	<md:EntityDescriptor entityID="https://login-idp-test.libraries.ch/idp/shibboleth">
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+	<EntityDescriptor entityID="https://login-idp-test.libraries.ch/idp/shibboleth">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">libraries.ch</shibmd:Scope>
+				<shibScope regexp="false">libraries.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="de">libraries.ch Test</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="en">libraries.ch Test</mdui:DisplayName>
@@ -1692,7 +1692,7 @@ Ofim
 					<mdui:GeolocationHint>geo:47.37643,8.54772</mdui:GeolocationHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1717,21 +1717,21 @@ Pw1Zuf7Bd34xBf3BlRiN3GY0ZO0WmhPCOiyXB6g1WlyKGcoIPUsuGAg0wF0=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://login-idp-test.libraries.ch/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://login-idp-test.libraries.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://login-idp-test.libraries.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login-idp-test.libraries.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://login-idp-test.libraries.ch/idp/profile/SAML2/POST/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://login-idp-test.libraries.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login-idp-test.libraries.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://login-idp-test.libraries.ch/idp/profile/SAML2/POST/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">libraries.ch</shibmd:Scope>
+				<shibScope regexp="false">libraries.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1756,12 +1756,12 @@ Pw1Zuf7Bd34xBf3BlRiN3GY0ZO0WmhPCOiyXB6g1WlyKGcoIPUsuGAg0wF0=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://login-idp-test.libraries.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://login-idp-test.libraries.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">libraries.ch</OrganizationName>
@@ -1770,10 +1770,10 @@ Pw1Zuf7Bd34xBf3BlRiN3GY0ZO0WmhPCOiyXB6g1WlyKGcoIPUsuGAg0wF0=
 			<OrganizationURL xml:lang="de">http://www.libraries.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="en">http://www.libraries.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- PHLU - Pädagogische Hochschule Luzern (Test IdP) -->
-	<md:EntityDescriptor entityID="https://idp.phlu-lab.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://idp.phlu-lab.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -1787,9 +1787,9 @@ Pw1Zuf7Bd34xBf3BlRiN3GY0ZO0WmhPCOiyXB6g1WlyKGcoIPUsuGAg0wF0=
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor errorURL="http://hotline.hslu.ch" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor errorURL="http://hotline.hslu.ch" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">phlu.ch</shibmd:Scope>
+				<shibScope regexp="false">phlu.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="de">PHLU - Pädagogische Hochschule Luzern (Test IdP)</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="en">PHLU - University of Teacher Education Lucerne (Test IdP)</mdui:DisplayName>
@@ -1806,7 +1806,7 @@ Pw1Zuf7Bd34xBf3BlRiN3GY0ZO0WmhPCOiyXB6g1WlyKGcoIPUsuGAg0wF0=
 					<mdui:GeolocationHint>geo:47.051064,8.302218</mdui:GeolocationHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1830,19 +1830,19 @@ vmCeOyaeLrfAWjuUhp+l56XmsmAt2QwMhDtF7ad/WhdWvYx8fsU0da7sr44=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://idp.phlu-lab.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.phlu-lab.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.phlu-lab.ch/idp/profile/SAML2/POST/SSO"/>
-		</md:IDPSSODescriptor>
+			</KeyDescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://idp.phlu-lab.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.phlu-lab.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.phlu-lab.ch/idp/profile/SAML2/POST/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">phlu.ch</shibmd:Scope>
+				<shibScope regexp="false">phlu.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1866,12 +1866,12 @@ vmCeOyaeLrfAWjuUhp+l56XmsmAt2QwMhDtF7ad/WhdWvYx8fsU0da7sr44=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://idp.phlu-lab.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp.phlu-lab.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">phlu.ch</OrganizationName>
@@ -1880,10 +1880,10 @@ vmCeOyaeLrfAWjuUhp+l56XmsmAt2QwMhDtF7ad/WhdWvYx8fsU0da7sr44=
 			<OrganizationURL xml:lang="de">http://www.phlu.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="en">http://www.phlu.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- PSI - Paul Scherrer Institut -->
-	<md:EntityDescriptor entityID="https://aaitest-logon.psi.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://aaitest-logon.psi.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -1897,9 +1897,9 @@ vmCeOyaeLrfAWjuUhp+l56XmsmAt2QwMhDtF7ad/WhdWvYx8fsU0da7sr44=
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor errorURL="http://www.psi.ch/computing/contact" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor errorURL="http://www.psi.ch/computing/contact" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">psi.ch</shibmd:Scope>
+				<shibScope regexp="false">psi.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="de">PSI - Paul Scherrer Institut</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="en">PSI - Paul Scherrer Institut</mdui:DisplayName>
@@ -1915,7 +1915,7 @@ vmCeOyaeLrfAWjuUhp+l56XmsmAt2QwMhDtF7ad/WhdWvYx8fsU0da7sr44=
 					<mdui:DomainHint>psi.ch</mdui:DomainHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1940,22 +1940,22 @@ CzdA8Q==
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aaitest-logon.psi.ch:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aaitest-logon.psi.ch:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aaitest-logon.psi.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aaitest-logon.psi.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aaitest-logon.psi.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aaitest-logon.psi.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aaitest-logon.psi.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aaitest-logon.psi.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aaitest-logon.psi.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aaitest-logon.psi.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">psi.ch</shibmd:Scope>
+				<shibScope regexp="false">psi.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -1980,12 +1980,12 @@ CzdA8Q==
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aaitest-logon.psi.ch:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aaitest-logon.psi.ch:8443/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">psi.ch</OrganizationName>
@@ -1994,10 +1994,10 @@ CzdA8Q==
 			<OrganizationURL xml:lang="de">http://www.psi.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="en">http://www.psi.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- Université de Neuchâtel - test IdP -->
-	<md:EntityDescriptor entityID="https://test-idp.unine.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://test-idp.unine.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -2011,9 +2011,9 @@ CzdA8Q==
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">test-idp.unine.ch</shibmd:Scope>
+				<shibScope regexp="false">test-idp.unine.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">Université de Neuchâtel - test IdP</mdui:DisplayName>
 					<mdui:Description xml:lang="en">Université de Neuchâtel - test IdP - test-idp.unine.ch</mdui:Description>
@@ -2022,7 +2022,7 @@ CzdA8Q==
 					<mdui:DomainHint>test-idp.unine.ch</mdui:DomainHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2047,22 +2047,22 @@ m/2zNvNzNBGi9p84KZ+Fn9S9GaFIx2wm9mWFCGQ4ClGXyXL9jnNADyYlrjuN30uA
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://test-idp.unine.ch/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://test-idp.unine.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://test-idp.unine.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test-idp.unine.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test-idp.unine.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://test-idp.unine.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://test-idp.unine.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test-idp.unine.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test-idp.unine.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://test-idp.unine.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">test-idp.unine.ch</shibmd:Scope>
+				<shibScope regexp="false">test-idp.unine.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2087,22 +2087,22 @@ m/2zNvNzNBGi9p84KZ+Fn9S9GaFIx2wm9mWFCGQ4ClGXyXL9jnNADyYlrjuN30uA
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://test-idp.unine.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://test-idp.unine.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">test-idp.unine.ch</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">Université de Neuchâtel - test IdP</OrganizationDisplayName>
 			<OrganizationURL xml:lang="en">http://www.test-idp.unine.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- CHUV Test IdP -->
-	<md:EntityDescriptor entityID="https://testidp.chuv.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://testidp.chuv.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -2116,9 +2116,9 @@ m/2zNvNzNBGi9p84KZ+Fn9S9GaFIx2wm9mWFCGQ4ClGXyXL9jnNADyYlrjuN30uA
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.chuv.ch</shibmd:Scope>
+				<shibScope regexp="false">test.chuv.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">CHUV Test IdP</mdui:DisplayName>
 					<mdui:Description xml:lang="en">Test Identity Provider for CHUV</mdui:Description>
@@ -2127,7 +2127,7 @@ m/2zNvNzNBGi9p84KZ+Fn9S9GaFIx2wm9mWFCGQ4ClGXyXL9jnNADyYlrjuN30uA
 					<mdui:DomainHint>test.chuv.ch</mdui:DomainHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2151,22 +2151,22 @@ K/Ry6U7sfhKgKvE76zKVzuNbTS8HqzEkLi08JNGBgWc=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://testidp.chuv.ch:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://testidp.chuv.ch:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://testidp.chuv.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://testidp.chuv.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://testidp.chuv.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://testidp.chuv.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://testidp.chuv.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://testidp.chuv.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://testidp.chuv.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://testidp.chuv.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.chuv.ch</shibmd:Scope>
+				<shibScope regexp="false">test.chuv.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2190,22 +2190,22 @@ K/Ry6U7sfhKgKvE76zKVzuNbTS8HqzEkLi08JNGBgWc=
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://testidp.chuv.ch:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://testidp.chuv.ch:8443/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">test.chuv.ch</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">CHUV Test IdP</OrganizationDisplayName>
 			<OrganizationURL xml:lang="en">http://www.test.chuv.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- SWITCH edu-ID [Test] -->
-	<md:EntityDescriptor entityID="https://test.eduid.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://test.eduid.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -2219,9 +2219,9 @@ K/Ry6U7sfhKgKvE76zKVzuNbTS8HqzEkLi08JNGBgWc=
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.eduid.ch</shibmd:Scope>
+				<shibScope regexp="false">test.eduid.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="de">SWITCH edu-ID [Test]</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="en">SWITCH edu-ID [Test]</mdui:DisplayName>
@@ -2241,7 +2241,7 @@ K/Ry6U7sfhKgKvE76zKVzuNbTS8HqzEkLi08JNGBgWc=
 					<mdui:DomainHint>edu-id.ch</mdui:DomainHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2265,21 +2265,21 @@ OKNguza3bi3RRsZUlDAJHSGHm+Fc3QLUPCDLZc0+OKcQbThC
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://login.test.eduid.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="1"/>
-			<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.test.eduid.ch/idp/profile/SAML2/Redirect/SLO"/>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.test.eduid.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://login.test.eduid.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://login.test.eduid.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://login.test.eduid.ch/idp/profile/SAML2/SOAP/ECP"/>
-		</md:IDPSSODescriptor>
+			<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.test.eduid.ch/idp/profile/SAML2/Redirect/SLO"/>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.test.eduid.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://login.test.eduid.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://login.test.eduid.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://login.test.eduid.ch/idp/profile/SAML2/SOAP/ECP"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.eduid.ch</shibmd:Scope>
+				<shibScope regexp="false">test.eduid.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2303,10 +2303,10 @@ OKNguza3bi3RRsZUlDAJHSGHm+Fc3QLUPCDLZc0+OKcQbThC
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://login.test.eduid.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">test.eduid.ch</OrganizationName>
@@ -2319,10 +2319,10 @@ OKNguza3bi3RRsZUlDAJHSGHm+Fc3QLUPCDLZc0+OKcQbThC
 			<OrganizationURL xml:lang="fr">http://www.test.eduid.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="it">http://www.test.eduid.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- FHNW-TEST - Fachhochschule Nordwestschweiz -->
-	<md:EntityDescriptor entityID="https://aai-logon.test.fhnw.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://aai-logon.test.fhnw.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -2336,9 +2336,9 @@ OKNguza3bi3RRsZUlDAJHSGHm+Fc3QLUPCDLZc0+OKcQbThC
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.fhnw.ch</shibmd:Scope>
+				<shibScope regexp="false">test.fhnw.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="de">FHNW-TEST - Fachhochschule Nordwestschweiz</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="en">FHNW-TEST - Fachhochschule Nordwestschweiz</mdui:DisplayName>
@@ -2349,7 +2349,7 @@ OKNguza3bi3RRsZUlDAJHSGHm+Fc3QLUPCDLZc0+OKcQbThC
 					<mdui:DomainHint>test.fhnw.ch</mdui:DomainHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2374,22 +2374,22 @@ yAC9nH+QiapYyPz1qWWsvFRG7/lpA2hc
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon.test.fhnw.ch:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon.test.fhnw.ch:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon.test.fhnw.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon.test.fhnw.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon.test.fhnw.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aai-logon.test.fhnw.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon.test.fhnw.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon.test.fhnw.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon.test.fhnw.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aai-logon.test.fhnw.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.fhnw.ch</shibmd:Scope>
+				<shibScope regexp="false">test.fhnw.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2414,12 +2414,12 @@ yAC9nH+QiapYyPz1qWWsvFRG7/lpA2hc
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon.test.fhnw.ch:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon.test.fhnw.ch:8443/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">test.fhnw.ch</OrganizationName>
@@ -2428,10 +2428,10 @@ yAC9nH+QiapYyPz1qWWsvFRG7/lpA2hc
 			<OrganizationURL xml:lang="de">http://www.test.fhnw.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="en">http://www.test.fhnw.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- SWITCH IdP Hosting Test Login -->
-	<md:EntityDescriptor entityID="https://test.idph.switch.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://test.idph.switch.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -2445,9 +2445,9 @@ yAC9nH+QiapYyPz1qWWsvFRG7/lpA2hc
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.idph.switch.ch</shibmd:Scope>
+				<shibScope regexp="false">test.idph.switch.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">SWITCH IdP Hosting Test Login</mdui:DisplayName>
 					<mdui:Description xml:lang="en">Test login for SWITCH IdP hosting</mdui:Description>
@@ -2455,7 +2455,7 @@ yAC9nH+QiapYyPz1qWWsvFRG7/lpA2hc
 				<mdui:DiscoHints>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2485,19 +2485,19 @@ I+Gw1TCc5NpI1S7PWrG94x7O9SnYNL/OzyLNew==
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://test.idph.switch.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="1"/>
-			<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test.idph.switch.ch/idp/profile/SAML2/Redirect/SLO"/>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test.idph.switch.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.idph.switch.ch/idp/profile/SAML2/POST/SSO"/>
-		</md:IDPSSODescriptor>
+			<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test.idph.switch.ch/idp/profile/SAML2/Redirect/SLO"/>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test.idph.switch.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.idph.switch.ch/idp/profile/SAML2/POST/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.idph.switch.ch</shibmd:Scope>
+				<shibScope regexp="false">test.idph.switch.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2527,20 +2527,20 @@ I+Gw1TCc5NpI1S7PWrG94x7O9SnYNL/OzyLNew==
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://test.idph.switch.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">test.idph.switch.ch</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">SWITCH IdP Hosting Test Login</OrganizationDisplayName>
 			<OrganizationURL xml:lang="en">http://www.test.idph.switch.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- University of Bern Test IdP -->
-	<md:EntityDescriptor entityID="https://aai-login.test.unibe.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://aai-login.test.unibe.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -2554,9 +2554,9 @@ I+Gw1TCc5NpI1S7PWrG94x7O9SnYNL/OzyLNew==
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor errorURL="http://www.id.unibe.ch/content/helpdesk/index_ger.html" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+		<IDPSSODescriptor errorURL="http://www.id.unibe.ch/content/helpdesk/index_ger.html" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.unibe.ch</shibmd:Scope>
+				<shibScope regexp="false">test.unibe.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="de">Universität Bern Test IdP</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="en">University of Bern Test IdP</mdui:DisplayName>
@@ -2573,7 +2573,7 @@ I+Gw1TCc5NpI1S7PWrG94x7O9SnYNL/OzyLNew==
 					<mdui:GeolocationHint>geo:46.9505,7.43814</mdui:GeolocationHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2598,17 +2598,17 @@ iHTraMOaCZWrdTour6KckJigCYEL6t11LM0eNw==
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-login.test.unibe.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-login.test.unibe.ch/idp/profile/SAML2/POST/SSO"/>
-		</md:IDPSSODescriptor>
+			</KeyDescriptor>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-login.test.unibe.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-login.test.unibe.ch/idp/profile/SAML2/POST/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.unibe.ch</shibmd:Scope>
+				<shibScope regexp="false">test.unibe.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2633,10 +2633,10 @@ iHTraMOaCZWrdTour6KckJigCYEL6t11LM0eNw==
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-login.test.unibe.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">test.unibe.ch</OrganizationName>
@@ -2645,10 +2645,10 @@ iHTraMOaCZWrdTour6KckJigCYEL6t11LM0eNw==
 			<OrganizationURL xml:lang="de">http://www.test.unibe.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="en">http://www.test.unibe.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- Université de Fribourg Test Home Organization -->
-	<md:EntityDescriptor entityID="https://testidp.unifr.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://testidp.unifr.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -2662,9 +2662,9 @@ iHTraMOaCZWrdTour6KckJigCYEL6t11LM0eNw==
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.unifr.ch</shibmd:Scope>
+				<shibScope regexp="false">test.unifr.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">Université de Fribourg Test Home Organization</mdui:DisplayName>
 					<mdui:Description xml:lang="en">L'Université suisse bilingue. Die zweisprachige Universität.</mdui:Description>
@@ -2673,7 +2673,7 @@ iHTraMOaCZWrdTour6KckJigCYEL6t11LM0eNw==
 					<mdui:DomainHint>test.unifr.ch</mdui:DomainHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2697,22 +2697,22 @@ qbvKmYxW/Y+CBrSxVLCBVQboAn6dFKGGIz+fCOY21W7uJCeNrioaeHCnFUB0tYZ6
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://testidp.unifr.ch/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://testidp.unifr.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://testidp.unifr.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://testidp.unifr.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://testidp.unifr.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://testidp.unifr.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://testidp.unifr.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://testidp.unifr.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://testidp.unifr.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://testidp.unifr.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.unifr.ch</shibmd:Scope>
+				<shibScope regexp="false">test.unifr.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2736,22 +2736,22 @@ qbvKmYxW/Y+CBrSxVLCBVQboAn6dFKGGIz+fCOY21W7uJCeNrioaeHCnFUB0tYZ6
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://testidp.unifr.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://testidp.unifr.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">test.unifr.ch</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">Université de Fribourg Test Home Organization</OrganizationDisplayName>
 			<OrganizationURL xml:lang="en">http://www.test.unifr.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- Universita della Svizzera Italiana -->
-	<md:EntityDescriptor entityID="https://tlogin.usi.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://tlogin.usi.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -2764,9 +2764,9 @@ qbvKmYxW/Y+CBrSxVLCBVQboAn6dFKGGIz+fCOY21W7uJCeNrioaeHCnFUB0tYZ6
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.unisi.ch</shibmd:Scope>
+				<shibScope regexp="false">test.unisi.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">Universita della Svizzera Italiana</mdui:DisplayName>
 					<mdui:DisplayName xml:lang="it">Universita della Svizzera Italiana</mdui:DisplayName>
@@ -2777,7 +2777,7 @@ qbvKmYxW/Y+CBrSxVLCBVQboAn6dFKGGIz+fCOY21W7uJCeNrioaeHCnFUB0tYZ6
 					<mdui:DomainHint>test.unisi.ch</mdui:DomainHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2801,22 +2801,22 @@ PIR6n9TcuIrrjSOKccQkfLNs+WFFD0pLZgl7Qcv18y7031/mQLDi4SF2R/zZuolo
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://tlogin.usi.ch:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://tlogin.usi.ch:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://tlogin.usi.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://tlogin.usi.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://tlogin.usi.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://tlogin.usi.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://tlogin.usi.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://tlogin.usi.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://tlogin.usi.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://tlogin.usi.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.unisi.ch</shibmd:Scope>
+				<shibScope regexp="false">test.unisi.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2840,12 +2840,12 @@ PIR6n9TcuIrrjSOKccQkfLNs+WFFD0pLZgl7Qcv18y7031/mQLDi4SF2R/zZuolo
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://tlogin.usi.ch:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://tlogin.usi.ch:8443/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">test.unisi.ch</OrganizationName>
@@ -2854,10 +2854,10 @@ PIR6n9TcuIrrjSOKccQkfLNs+WFFD0pLZgl7Qcv18y7031/mQLDi4SF2R/zZuolo
 			<OrganizationURL xml:lang="en">http://www.test.unisi.ch/</OrganizationURL>
 			<OrganizationURL xml:lang="it">http://www.test.unisi.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	<!-- Test Virtual Home Organization -->
-	<md:EntityDescriptor entityID="https://aai-logon.test.vho-switchaai.ch/idp/shibboleth">
+	<EntityDescriptor entityID="https://aai-logon.test.vho-switchaai.ch/idp/shibboleth">
 		<Extensions>
 			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
 				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -2871,9 +2871,9 @@ PIR6n9TcuIrrjSOKccQkfLNs+WFFD0pLZgl7Qcv18y7031/mQLDi4SF2R/zZuolo
 			</mdattr:EntityAttributes>
 
 		</Extensions>
-		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+		<IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.vho-switchaai.ch</shibmd:Scope>
+				<shibScope regexp="false">test.vho-switchaai.ch</shibScope>
 				<mdui:UIInfo>
 					<mdui:DisplayName xml:lang="en">Test Virtual Home Organization</mdui:DisplayName>
 					<mdui:Description xml:lang="en">Test Virtual Home Organization</mdui:Description>
@@ -2882,7 +2882,7 @@ PIR6n9TcuIrrjSOKccQkfLNs+WFFD0pLZgl7Qcv18y7031/mQLDi4SF2R/zZuolo
 					<mdui:DomainHint>test.vho-switchaai.ch</mdui:DomainHint>
 				</mdui:DiscoHints>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2908,22 +2908,22 @@ NaJ5zpd0pEiy3dSqZQ==
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon.test.vho-switchaai.ch:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
 			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon.test.vho-switchaai.ch:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon.test.vho-switchaai.ch/idp/profile/Shibboleth/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon.test.vho-switchaai.ch/idp/profile/SAML2/Redirect/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon.test.vho-switchaai.ch/idp/profile/SAML2/POST/SSO"/>
-			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aai-logon.test.vho-switchaai.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
-		</md:IDPSSODescriptor>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+			<SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon.test.vho-switchaai.ch/idp/profile/Shibboleth/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon.test.vho-switchaai.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon.test.vho-switchaai.ch/idp/profile/SAML2/POST/SSO"/>
+			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aai-logon.test.vho-switchaai.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</IDPSSODescriptor>
 		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
 			<Extensions>
-				<shibmd:Scope regexp="false">test.vho-switchaai.ch</shibmd:Scope>
+				<shibScope regexp="false">test.vho-switchaai.ch</shibScope>
 			</Extensions>
-			<md:KeyDescriptor use="signing">
+			<KeyDescriptor use="signing">
 				<ds:KeyInfo>
 					<ds:X509Data>
 						<ds:X509Certificate>
@@ -2949,20 +2949,20 @@ NaJ5zpd0pEiy3dSqZQ==
 						</ds:X509Certificate>
 					</ds:X509Data>
 				</ds:KeyInfo>
-			</md:KeyDescriptor>
+			</KeyDescriptor>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon.test.vho-switchaai.ch:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
 			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon.test.vho-switchaai.ch:8443/idp/profile/SAML2/SOAP/AttributeQuery"/>
-            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 		</AttributeAuthorityDescriptor>
 		<Organization>
 			<OrganizationName xml:lang="en">test.vho-switchaai.ch</OrganizationName>
 			<OrganizationDisplayName xml:lang="en">Test Virtual Home Organization</OrganizationDisplayName>
 			<OrganizationURL xml:lang="en">http://www.test.vho-switchaai.ch/</OrganizationURL>
 		</Organization>
-	</md:EntityDescriptor>
+	</EntityDescriptor>
 
 	
 
-</md:EntitiesDescriptor>
+</EntitiesDescriptor>

--- a/test/data/idp_federation_metadata.xml
+++ b/test/data/idp_federation_metadata.xml
@@ -1,0 +1,2968 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" xmlns:shibmd="urn:mace:shibboleth:metadata:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="AAITest-20190613090159" Name="urn:mace:switch.ch:aaitest" validUntil="2019-06-18T07:01:59Z" xsi:schemaLocation="urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"><ds:Signature>
+<ds:SignedInfo>
+<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+<ds:Reference URI="#AAITest-20190613090159">
+<ds:Transforms>
+<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+<ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+</ds:Transforms>
+<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+<ds:DigestValue>mVOzlcIiq4YtwGSPbxjRnNJyqYqS/TO+fUxqu/L/kz8=</ds:DigestValue>
+</ds:Reference>
+</ds:SignedInfo>
+<ds:SignatureValue>
+F/VoOtNVRXlunkKYFK8qVg4SvUSzRtth2YgQfEVbHOQ32DtHh/AXNFBbcn/4LVtPLCZh8tMWjGB4
+4OTwMLYPCnE1fuxbb6iYQ3NdWsAsaFgF26WBFTi/JlCrH5OfVaxZWZMTG7AeOwjn33Ydgng6gdLh
+wB6Fyvda/TqATVDaNDtSD+y+nLGI6rUUJpcSof6/6tbv5mkriSJQHi9icKjyOZqWjQXIVu3rXlcp
+gTtl9uogyPdvkMJOXULoeWnWkph0En61AGaepJJ3KnO24v9XFGRpmMTwhOiLTYaxy6yk42jv3mLv
+TEM8+bILcBog+PgBnwVpXQ73nTx9cqFu2f0JOA==
+</ds:SignatureValue>
+<ds:KeyInfo>
+<ds:KeyValue>
+<ds:RSAKeyValue>
+<ds:Modulus>
+tLrTOviM+73OFe+Z7A5B2b7CM3sHCZIXFSthiSxMrXG5ENgXwDGCfqQTM1lIIk86QgJ4YvEB40AO
+p3+HhHTOJC+VoFUMGwTw8V4Zln+krQBmfTuNUZnTuzptXjrjaCs3cu7YOujnPfYC2iJKsIneN2sD
+UrqlH6wh/BFOTWVlRe1bgnXA+FtQJsLvMjmZ2xBFI6cFHPc0l67Tm9wu9js3Hpw3ZRXGK8XHvFHC
+/kGqSGZ+qxRoUFQLMFbjng+hvjubFb1wRMM/3YLiqm/cJlwwm3L9JrtTT39g/1e+rPhZT1hJO/sj
+8ZIdYYsA1ReO4G7R1b2NF8WqjCq+l01PfloxfQ==
+</ds:Modulus>
+<ds:Exponent>AQAB</ds:Exponent>
+</ds:RSAKeyValue>
+</ds:KeyValue>
+<ds:X509Data>
+<ds:X509Certificate>
+MIIEJjCCAw6gAwIBAgISSWITCHaaiMetadataSig2018MA0GCSqGSIb3DQEBCwUAMEYxCzAJBgNV
+BAYTAkNIMQ8wDQYDVQQKEwZTV0lUQ0gxJjAkBgNVBAMTHVNXSVRDSGFhaSBNZXRhZGF0YSBTaWdu
+aW5nIENBMB4XDTE4MDYwMTA3MDAwMFoXDTIwMDcxNTA2NTk1OVowQjELMAkGA1UEBhMCQ0gxDzAN
+BgNVBAoTBlNXSVRDSDEiMCAGA1UEAxMZU1dJVENIYWFpIE1ldGFkYXRhIFNpZ25lcjCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBALS60zr4jPu9zhXvmewOQdm+wjN7BwmSFxUrYYksTK1x
+uRDYF8Axgn6kEzNZSCJPOkICeGLxAeNADqd/h4R0ziQvlaBVDBsE8PFeGZZ/pK0AZn07jVGZ07s6
+bV4642grN3Lu2Dro5z32AtoiSrCJ3jdrA1K6pR+sIfwRTk1lZUXtW4J1wPhbUCbC7zI5mdsQRSOn
+BRz3NJeu05vcLvY7Nx6cN2UVxivFx7xRwv5BqkhmfqsUaFBUCzBW454Pob47mxW9cETDP92C4qpv
+3CZcMJty/Sa7U09/YP9Xvqz4WU9YSTv7I/GSHWGLANUXjuBu0dW9jRfFqowqvpdNT35aMX0CAwEA
+AaOCARAwggEMMA4GA1UdDwEB/wQEAwIHgDAdBgNVHQ4EFgQU36lyRNM+aRWZwj1ZXKQ3cmLKikYw
+HwYDVR0jBBgwFoAUkAqRwu5oLhVuFP7yzr0RUYoeNd8wTAYDVR0fBEUwQzBBoD+gPYY7aHR0cDov
+L2NybC5hYWkuc3dpdGNoLmNoL1NXSVRDSGFhaU1ldGFkYXRhU2lnbmluZ0NBMjAxNS5jcmwwVgYI
+KwYBBQUHAQEESjBIMEYGCCsGAQUFBzAChjpodHRwOi8vY2EuYWFpLnN3aXRjaC5jaC9TV0lUQ0hh
+YWlNZXRhZGF0YVNpZ25pbmdDQTIwMTUuY3J0MBQGA1UdIAQNMAswCQYHYIV0AQIGBzANBgkqhkiG
+9w0BAQsFAAOCAQEANOvsxf54rvakxb8Q/dVlw/hs3BxcYh84BgzUIGxs1q8EjpIFgI62ODM9QSHy
+Ia+PXYwKcZRFw6imzNGMaDm+v34XAJEn5sn5OYx3kkDAEoLh1ZlTZCFm1NnP1lb/CbEKn2PV4cdw
+pLlvu0MipHRR17Ho5a7gGV9C9ULGIreFH8OjpX3oaE6LonvGdGZk66utOrQgD2nbRGHQRWD9+dVY
+KT3q9Vwen6AUoOVC9Ue1C7gKZ8xYWCbQu000a4csqEmWDD6LS/ZkvTgmYeFcFhZ7DztFTVOZGYbk
+5sADshjZZBSQAJhaglMaI/r/BXSng+/JcVzHq04A5oH9yggFEzjr2g==
+</ds:X509Certificate>
+<ds:X509Certificate>
+MIIESjCCAzKgAwIBAgISSWITCHaaiMetadataSignCA2MA0GCSqGSIb3DQEBCwUAMGsxCzAJBgNV
+BAYTAkNIMUAwPgYDVQQKEzdTd2l0Y2ggLSBUZWxlaW5mb3JtYXRpa2RpZW5zdGUgZnVlciBMZWhy
+ZSB1bmQgRm9yc2NodW5nMRowGAYDVQQDExFTV0lUQ0hhYWkgUm9vdCBDQTAeFw0xNTA3MTUwNzAw
+MDBaFw0yMDA3MTUwNjU5NTlaMEYxCzAJBgNVBAYTAkNIMQ8wDQYDVQQKEwZTV0lUQ0gxJjAkBgNV
+BAMTHVNXSVRDSGFhaSBNZXRhZGF0YSBTaWduaW5nIENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEApYAlCv+zsEXlLR2aeX83+SaGmAInwLVa9ihgMm99xlIp/rjqzawPj6qI9OIqJSth
+P6/9FrWzc20AsL4lwUhJfm2cQEBFfzQ7bFVXqSY9+3bKdpTXz962RcPMdM1GRHfVDS/C7uJySZcU
+CfoK9IWPkdJ9KIe3gqjUWGCg9+Ghu/7K/HnduGTc2/wMrIRI2S8QuflThCvFVM2PeXDTxItQSoAJ
+4MM9v3Up1fbp5bqc5qPKqpn0D0AB46e++gZjAlNBm0vQm2Qw0/Ru3/X8xf1TKK5Za/MxHRaS4KR6
+0V2UdiTX17HApNNtvnd/cc8eQ3l/lvQkWPUe5aEgMDd/9BRn0wIDAQABo4IBCzCCAQcwDwYDVR0T
+AQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHwYDVR0jBBgwFoAU6ZriBljrD9eBA11cl7mxtZN9
+O4QwHQYDVR0OBBYEFJAKkcLuaC4VbhT+8s69EVGKHjXfMD0GA1UdHwQ2MDQwMqAwoC6GLGh0dHA6
+Ly9jcmwuYWFpLnN3aXRjaC5jaC9TV0lUQ0hhYWlSb290Q0EuY3JsMEcGCCsGAQUFBwEBBDswOTA3
+BggrBgEFBQcwAoYraHR0cDovL2NhLmFhaS5zd2l0Y2guY2gvU1dJVENIYWFpUm9vdENBLmNydDAc
+BgNVHSAEFTATMAYGBFUdIAAwCQYHYIV0AQIGBzANBgkqhkiG9w0BAQsFAAOCAQEAXaxkC++VrBse
+smh7TteSsvD2S8s5m7ydMw5GviGQjXLhzHQQifiJcOOsIpFO7y5/1RJZUzgf3D+O6PLY2DJhFY/F
+A2y/SRT3qNUb1EAVq+AtNXKEvmxZXcpNhdzJCONRXkNm25MvPtcfpBTfKVhW8PkSM0H5p9v5U/N2
+lU/TS7Bkwzc5deaKIoqvh+l/bjzsB3QdR6UXQ0lUcB1ve4iW4e+4SVJGCXhoMsX3QNfyKPWYsELU
+GsQCaifc7nCXtL8TuO5CwzQG5uNfQ5PRugv63S4FS788OA8ZGSIl74KMC10C84GhJsSe1C6UZgCl
+z3067iyasJWjISXYDKk3pwpZIg==
+</ds:X509Certificate>
+<ds:X509Certificate>
+MIIDnzCCAoegAwIBAgINSWITCHaai+Root+CAzANBgkqhkiG9w0BAQUFADBrMQswCQYDVQQGEwJD
+SDFAMD4GA1UEChM3U3dpdGNoIC0gVGVsZWluZm9ybWF0aWtkaWVuc3RlIGZ1ZXIgTGVocmUgdW5k
+IEZvcnNjaHVuZzEaMBgGA1UEAxMRU1dJVENIYWFpIFJvb3QgQ0EwHhcNMDgwNTE1MDYzMDAwWhcN
+MjgwNTE1MDYyOTU5WjBrMQswCQYDVQQGEwJDSDFAMD4GA1UEChM3U3dpdGNoIC0gVGVsZWluZm9y
+bWF0aWtkaWVuc3RlIGZ1ZXIgTGVocmUgdW5kIEZvcnNjaHVuZzEaMBgGA1UEAxMRU1dJVENIYWFp
+IFJvb3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDUSWbn/rhWew/sLJRyciyR
+KDGyFXSgiDO/EohYuZLw6EAKLLlhZorNtEHQbbn0Oo13S33MclHMvGWTKJM0u1hG+6gLy78EPmJb
+qAE1Uv23wVEH4SX0VJfl3JVqIebiAH/CjuLubgMUspDIjOdQHNLS7pthTbm7Tgh7zMsiLPyMTZJe
+p5CGbqv8NoK6bMaF0Z+Bt7e1JRlhHFCViJJaR/+hfpzLsJ8NWVivvrpRGaGJ1XR+9FGsTkjNdMCi
+rNJJZ6XvUOe5w7pHSd9McppFP0eyLs02AMzMXI4iz6PK/w3EdzXGXpK+gSgvLxWYct4xHpv1e2NX
+hNgdJOSN9ra/wJLVAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMB0G
+A1UdDgQWBBTpmuIGWOsP14EDXVyXubG1k307hDANBgkqhkiG9w0BAQUFAAOCAQEAMV/eIW6pFB+m
+bk7rD7hUPTWDRaoca3kHqmFGFnHfuY8+c0/Mqjh8Y/jyX1ybf58crTSWrbyGbUZ3oxDGQ34tuZSk
+meR32NqryiX3sP5qlNSozVguQKt8o4vhS1QeWPsXALs3em2pdKuIGSOpbuDnopPcmU2g5Zi2R5P7
+qpKDKAKtNUEwV+LW7GBMEksONj7BFXk4AFBFBijaYJGgHmoKSImVgeNIvsV+BSv5HJ4q6vcxfnwu
+vvGHM0AGphYO6f5qtHMUgvAblI8M/2QsBgethaGrirtKJ3aCRLdaR2R1QfaGRpck/Ron5/MpMxiJ
+wLT8YlW/zjx2yNABhPSAjfzeMw==
+</ds:X509Certificate>
+<ds:X509CRL>
+MIIB9jCB3wIBATANBgkqhkiG9w0BAQsFADBGMQswCQYDVQQGEwJDSDEPMA0GA1UEChMGU1dJVENI
+MSYwJAYDVQQDEx1TV0lUQ0hhYWkgTWV0YWRhdGEgU2lnbmluZyBDQRcNMTkwNjEzMDU0MzAzWhcN
+MTkwNjE4MDU0MzAzWjAzMDECEkliEwh2mojHrWnWrWkooNtNeRcNMTgwNzE2MDcwMDAwWjAMMAoG
+A1UdFQQDCgEEoDAwLjAfBgNVHSMEGDAWgBSQCpHC7mguFW4U/vLOvRFRih413zALBgNVHRQEBAIC
+BZIwDQYJKoZIhvcNAQELBQADggEBAACkqnhm5pDvtpu6gVPWnYcN55hklrNIBbzsOaflnj+74Vjx
+Ze3NMp50aw12qGC4Fide7tS7Eb6n409PivmCaxiOwRlymtaGLSvXsCqI4jzlNYu4h385EKh3IoUf
+B5UVQCEnncgdbs6eU3tJKtgimn+HnXZe8+IuCYlGBvzBos/f+zJAycGML+u2zNiJotvzhcZbLujB
+Qp6hgVxzUkIm1NfVSQWAkhHeZ7asVKl9iWs/6Iq8+jT7qU4mPmVtCipUiJTiQpM36cEEY3KE/stl
+eRgv0Cf/J7B2WqXkBm3mNe2wZy/v+NV2whaK12y3Cws9N784EsXANwun21o8JuunPN0=
+</ds:X509CRL>
+<ds:X509CRL>
+MIIChTCCAW0CAQEwDQYJKoZIhvcNAQELBQAwazELMAkGA1UEBhMCQ0gxQDA+BgNVBAoTN1N3aXRj
+aCAtIFRlbGVpbmZvcm1hdGlrZGllbnN0ZSBmdWVyIExlaHJlIHVuZCBGb3JzY2h1bmcxGjAYBgNV
+BAMTEVNXSVRDSGFhaSBSb290IENBFw0xOTAzMzAxMzI0MTVaFw0yMDA5MjgxMzI0MTVaMIGcMDEC
+EkliEwh2moiJ7RXnTA0ooJwgNBcNMTUwOTAxMDcwMDAwWjAMMAoGA1UdFQQDCgEFMDECEkliEwh2
+mojHrWnWrWkooJwgNRcNMTUwOTAxMDcwMDAwWjAMMAoGA1UdFQQDCgEFMDQCFUliEwh2mojHrWnW
+rWkooJ4p4AgNcBcNMTUwOTAxMDcwMDAwWjAMMAoGA1UdFQQDCgEFoC8wLTAfBgNVHSMEGDAWgBTp
+muIGWOsP14EDXVyXubG1k307hDAKBgNVHRQEAwIBDDANBgkqhkiG9w0BAQsFAAOCAQEAWf7o16Z2
+q4O6qmJdbg+3HHJD3M4byGGgv9t4cp9fVPcDRKOxYd5BnvIp6daZV14W7GKJ7BX4K5gt9629nme0
+IVLqm+Fq8qCy38HA30Sr5tjFVGFAOzcLzzMJHuTNp+d5riK4vlMBY3VEfQeFDqZGw4CfqjIYDUPY
+49AXLwkH8Npgjjc9YDicZIh6osk2RJxHOfBaD7/5ETJPZ/0irgb3VWBjzpD6HI9DtXQnTi6DFLhs
+SUZR93T4O8wD8XuP2e6pEevpQnIaijFOSSA1c+oXO4o04zESj617VFCA1J4f2NqDV7LGZm1dT/Ro
+kTrorHQ4/wGoDIpifcLse8Rj3PZdMQ==
+</ds:X509CRL>
+</ds:X509Data>
+</ds:KeyInfo>
+</ds:Signature>
+<!--
+		This metadata file is generated for the AAI Test federation,
+		which is for development and testing purposes only!
+		Use at your own risk. SWITCH won't take responsibility
+		for the data included in this file.
+-->
+	<Extensions>
+		<mdrpi:PublicationInfo creationInstant="2019-06-13T07:01:59Z" publisher="http://metadata.aai.switch.ch/metadata.aaitest.xml">
+		</mdrpi:PublicationInfo>
+	</Extensions>
+
+    <!-- Identity Provider Metadata -->
+
+	<!-- AAI Demo Home Organisation -->
+	<md:EntityDescriptor entityID="https://aai-demo-idp.switch.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">aai-demo-idp.switch.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="de">AAI Demo Home Organisation</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="en">AAI Demo Home Organisation</mdui:DisplayName>
+					<mdui:Description xml:lang="de">AAI Demo Home Organisation</mdui:Description>
+					<mdui:Description xml:lang="en">AAI Demo Home Organisation</mdui:Description>
+					<mdui:Keywords xml:lang="en">demo</mdui:Keywords>
+					<mdui:Logo height="16" width="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAAXNSR0IArs4c6QAAAJ9JREFUeJxi+E8iYKCjhl27djGgAl5eXi0trZaWlq9fvxKlAQ5SUlLwafDw8JgFBsXFxZycnEARRkbG9+/f49RQUVEBFwwKCoIInj17ligNQMdABHfu3EkbDbGxsRDBPXv2EKVBW1sbInjx4kWcGiwtLavAAMiAiLCwsLx7946EeIiOjsYXD3DAysqqrq5eWFiIPaaJBCRrAAAAAP//AwAAtBdgPg/CYgAAAABJRU5ErkJggg==</mdui:Logo>
+					<mdui:Logo height="60" width="80">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAA8CAYAAADxJz2MAAAAAXNSR0IArs4c6QAADYNJREFUeJzsW2dUVNcWRhFr7GKJXSPGnjyINU/FgqDBLEuIDaOxYhcLSuyKFSyxRVCXNWosK2KBGQYEBOkKI71XQWZgqIqIzjsfa7brhgU4jXeDyY+95p6zzz1z7zf77H32d/boyOVynX9FfeH9AWq78P4AtV14f4DaLrw/QG0X3h+gtku1ysjIyD46bAhXzp0797M64wwNDYNJV9X3CYXC8RXngTRt2rSgb9++EXv27PmluLi4Md+gKQ2gg4ODdcWXmTZt2i11xmkCIFcWLlzoxDdoSgM4duxYER5aT0+vdMSIET64btasWX5paamequNUBdDU1NTF0dFxEWTdunX2jRo1eoX+OnXqvJfJZC34Bu6jABYWFn5Wv379N3job7/99rG9vf06ejkPDw9jVcepCuCmTZv2cXVTp069TbqQkJD/YCkD2B49eiQ0bNjwddu2bV+amJgIwsPD+2H83r17N7dr1y5rzJgx7ocPH16L644dO6avXbv2cFJSUrehQ4f64Z758+efj4+P74l7ioqKmqxZs+ZIt27dkjBn8+bN8/r37//88uXLc1QG8O7du5Ppgbdv374jNDR0ELXXr19/SNVxmgKIpUs6gUBgYmdnZ0ttgFOvXr23uB44cGAYxtva2tqhDcuF1XLdwJAhQ/y5bfw4uOfAgQMbK3MbdevWfQfQVQJw6dKlp2kCb2/v/75//74OfjG04dBVHadtAAcPHhyAawsLixvQe3p6jiJ9YmJidwIQ8uDBg4n37t37juseYmJiDIYPH+6Ldu/evaMxh7GxsQfaX3311TMExvv370+ie86fPz9fJQC7du2ajBthypmZme1zcnJaTZky5Q5NmJyc3FWVcZoCaGlpeYl0IpFoLJYu+drOnTuntm/fPpP0/v7+QwjANm3aSHD/69evG5L+1KlTVuiDC0AbSxbtQYMGhaK9YsWK4/S9LVq0kKEPrklpACMiIvp+LBqePHlymbLjtAFgv379wkkXFhY2sEuXLim4xrwrV678lSvR0dG9CcBOnTql4f6SkpIGFa3JxsZmPxdA+Du0V69efZS+t1WrVjnow/JWGkBuIKhKJk2adF/ZceoAOGzYsCcAAYJr6oevy83NbUnzzZkz5zLuTU1N7bxx48YDkJSUlC7qADhq1ChPtCdOnPjg3bt3dbOzs/V1dXXL0Ofk5LRQaQBpWwJ5+PChGSyNBF+G/saNGxePHj36kTLjsHy0tQ+cPXv2FYzdvHnzXgIUPxKCB9oIGFKptLU6AG7dunUXjUFggluiNkV3pQCkbQl8S0Ud/APXGpQZ5+LiYqoJgNhfwtFjC0KZCPaC8IvIUsgXYmtCGZA6AMKyZ82adRU/Oo1FQESiUNUzVxlEapNgL6rtOQsKCpq+efOm/sfG8f7ytV14f4DaLrw/QG0X3h+gtgvvD1DbhfcHqO1SaWdGRsbntA8yNzd35upmzpz5O+mQkPP9AnzLvwD+C2DNSFlZWTsm7TUGEHkmclkS8G8VAbxy5crsAQMGiMHgIn8EU7Jq1apjYHihBxmA3HLfvn2bJk+efBfpF9gVcHS4t3v37ongDkHIsofWxT1gVJDUd+jQ4UWDBg1KQJuBJaE5a0rYO/Z3W7TlSXiXKbLQL6ZJBat2eb5IT5+qNoDVCQAEHQ7GtjI95ZC9evWKRbtJkyZFXL2BgUEM8W0k165dm4F7QGqijbm5XN/u3bu31BR4iTGxP8c+j7BKiIpe6Dd4bmqBzlh5PpM8JgEP3faDLNY6gKdPn15KLAiY36ioqC+JGQHzywUQVgfLWrRokSMX5MDAwG+INtqyZctu0FGkv3nz5nTMsWzZspNoGxkZBdUEeG/fvu0Up/9d0fPA4PVo58lkoxJbTyqW6oyRS3SM5UU64+TPA4I2qAwg2AywHiREUxGAOKsl+ofuJ4Bw9sAFECCgfenSJUuaQyKRtEEfGB20N2zYcDA4ONiQ9LA+6OAe0IZ7qAkAk2Lj5pXojJc/Nl4Uz8Dsgr6oZ2GrYIXZDMAcBmR864mg5gaoBODHgsjOnTu34Rq+isYsWbLkN/SBwuICaG1t7YA2TrloDmJSiKIHgAEBAYNJP2PGjGtcthkUlLZAKykp6Utgif2DNsLKCpm42hwQsuXaAP0ejlcuoB8gFrNP799vn9IqgCdOnFiOa3CIIDLB5OJ4EX34VAfAhISEHqR3dnY2hx7uAWwzjiu1AV5KQoJlROfv83KkOePQTktOmUHWBsD87rmWnygyIJu7zd4QDJ2MWaH75BXhrO/DebfGAOJ8gtqIllyHv2PHju3qAIgfAQEGbX19/WxE/tatW0vRBluuCXDs5Zv53L53NJeBAWvzueV8DP3YsjwzmC7JUfg8qe7Yd2lJyTOhQ2QONfhBgoDiM/SnFDbHZ1oDEH1HjhxZwwUOZ7FYemB41QEQbQQWBAyw0ejHofiECRNccdyoCYBYsgAKkRVAydgnoi90T718txYrlisAFveYlvPq1auB0KWnpFrk6pmUCZZu82EA1q0WQHUFDK622WFYozb2fmwefbqWZGebpTQ1K5EqgkN0x+/z2XcYYWkKfrF3eaUAERYnmrHuKZZxOcAM+KS4+J+482oVwL+jYO/2nAWIEEPL9GfeT7YgOGC5BriI9uUrfB4+PcyXRzCQ4cNbuB08fQs+r5DJaxaZH01bGyb2C7TJSEubzu7X/ccAyID6HGDA15HPE67Y5YXlGCN+vtztsOMNBIyXisAhZGMBOJYowBIdO3cN40WHnW5kvXjxfWXfwftL1qTAatwtbYKyy33dmA/WFq0/qSjAcE66NDvbVGRh/YwsERYX6uNnq8p38P6SNSEJ0TELsDGmdmZGxhTvcYtjCxWBA74Pfs7P2cWeRdh+8IHwhehPamLyJtjda2dxUZHhPw5AtvQae1+9fbpUx0SezbYhBQUFw0hXXFz8tfvJC1cyGo0vhTUCsMABMzNxDwJDTh3j97QHDB406wX3Xo0BZKG/Hs5J+QaoOmE7gF5gTTwv3HCKDAld48U+Xa3t3AEQ9MwfdgwUuNshn4U1UtaRGBtXfsjufubSxTIGvJBFYcpONAIQ9XALFiw4i+omqq9DJQJop/3799tge8E3aCRSiWRC0NezMrxMraIZYOU/NEvT+uTn54/g7tmkEqmJYPXuR0jhHrEUDctYsHirL3Qhjx5vf3Ln/hFK4TQCkH1xM8oEqhJu8SRfwl62Hja/L/XGl32IsvtP3kEkxbIUWO14zK4bce8JDwpZh+iLa1isn9GcNAXQKgFXLYDcqlNkCLC4ixcvzgVoxP2hFuVvAGAT/wfCA97GC+PzOJEUy7SosPAbuc4E+eMbf56oeJ+bw5k/3OxO/BkXGbWYZRqDSktLe6r7DJV2grQkAI8fP76Cq+OWmqF4EjV1oLKQzqHCs2XLlrmocsJYFAKhmgoFOqCkUNQDrhDjjx49ulpbQCJiRoIYUETS5Oamr2PE4cue3HVxgL/DHi7U13+zLFc2GuNBHABc0bGz19iP8NH6F5UBBOtRkSEmAcVPOrFYPIDKealKCoL8FdQ8yATusscYAIxr1DirYXF1EE2xCY4OFa9kaeMQ0mHbIlMQAfj0N7JMw0Ya2QWCQpDbo91+w+cl46wDSzc8+GmVFVe8AIhawaCgICPSIQhR/SBIgbi4uC/ALpNeVQDh715mZpmLDX6QvGHpFaJolt64MpGD4x+IsBjjc9P5V+LukIopfGBD6LCpluuYyrHN0ZblKwXg1atXZ3F1ZmZmDysDcNu2bTuhR9E5GGnQ8lRzTEw0hP7voQqAzEf1EFrvdccGl1lTVyw9BAyJguR0n7paDCsDWK4s9eLyeo//uHsckdnDzCpKuOmgQBN/pzSAhw4dWk8gVawNpsMeCIrKCUDi/rhCNccEIJYgOENlAcT4l1lZ3/kPnZcCoJJamr3Kk8lGIrISyUl5rOvaPR5gUwA20jRu6oZIjcMiTf2d0gCiopRAwj4QVoXAwv2zCwhOjK0OQPrX0siRI70QULhF6QQg6HtUk1ZWBc82xwZeYxbHUYQFKE8YmFiy2Ofh2DFXARQskghQ5Lix7cwL0RfGljyIAW0DVy2AeFk6WatKCLDqAESlPY1H2SyETt8IQDrV69mzZ3wlFliPBYGWnheuO5FvwzbFdf1eETEmEpaySRQAYntC9wotNwZ5WFg/I0L0/wogBFXv8GVEpUPw8n369ImEtdAZaXUAglwFM40xYJTPnj27gP42QGcb1QHIAbKp4Gdb/7+cWTi72JdbsItoH9qwUrDFivG6sEYGfquaBK9aALmCPw3m5eU1r+xguTpBkLl+/fqPrq6uE9BGTk2V72fOnFmsylxsyX75tK/Fy1zFVgXJP0DCMwlsD7oiMoPPq2nA1AJQXcEmnCwXWcz06dNvkjX7+voOV3U+0FJZDca9lSjOLCK6Tc2FL2SWPhh5bXpK6o+fFICI0nRgToJU0MrK6pS6cwaLPHcVcs4shHM3BQI4nN9yjxs/CQAhyEhw9Ik/IqLiAP/+0WS+8oOfnUfvATxYIfwiRV8+hJcv1VSYL+0c3cG8QMy2MTjf4PNZeAdDHWHRta3Q/rebNb1F+WQBVHU3UJPyPwAAAP//AwAFjkkeCbTOgAAAAABJRU5ErkJggg==</mdui:Logo>
+					<mdui:InformationURL xml:lang="en">https://www.switch.ch/aai/demo/</mdui:InformationURL>
+					<mdui:InformationURL xml:lang="de">https://www.switch.ch/aai/demo/</mdui:InformationURL>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>aai-demo-idp.switch.ch</mdui:DomainHint>
+					<mdui:DomainHint>example.org</mdui:DomainHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDODCCAiCgAwIBAgIJAK1/mY3/13x1MA0GCSqGSIb3DQEBBQUAMCExHzAdBgNV
+BAMTFmFhaS1kZW1vLWlkcC5zd2l0Y2guY2gwHhcNMTkwMzE1MDcyMzI0WhcNMjIw
+MzE0MDcyMzI0WjAhMR8wHQYDVQQDExZhYWktZGVtby1pZHAuc3dpdGNoLmNoMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr7tKI/3W0h5EO9/o7aB2A1HH
+yIo6zQjakCVCq/aQnzBzITpvC/SkJQQk6GvIul6t4J4J4vE2YRud6EGcQB1Qn2Oi
+hatWfIFT9DO4Zr9imVLA4V/q5CzCk9VX1lVhX9WEtnnrbdhU/iUpQw9B+N+iIDt9
+zjHMW5PS7QQ0Pl5aSJy8S5rH4mr2RILMPWq9UpUXuyCFv4WQ6CvngzhgfJSzH7VO
+2XV22jTlox5tAjguoaBOuFefMOjy1JCmMYSWWUG3qHDCfvAzIoFRvwI4N8IX22rh
+MN9TfKyyOaL+v1t4A+39rnjv8VcvWL0pJdOWFT34+YxII6Rodg0WuyiLfut62wID
+AQABo3MwcTBQBgNVHREESTBHghZhYWktZGVtby1pZHAuc3dpdGNoLmNohi1odHRw
+czovL2FhaS1kZW1vLWlkcC5zd2l0Y2guY2gvaWRwL3NoaWJib2xldGgwHQYDVR0O
+BBYEFNhlyhfnqzkYtuVcMrRAYtm2SJuTMA0GCSqGSIb3DQEBBQUAA4IBAQBsgcpL
+xRBBvFox/O23j32e1rHmYzYHXlDdFllbhQiwOxw3I5DvUAFmmC8TUvLRUBTSObwZ
+EjnztX2J0hcokkM+Tmvo4s5FTIgq0KQqQXmbmDhDg/5zx1lpp8c7u8zigc/YV2TT
+ekuCZ6Gb7GkjuZivrLMUMhMrdD9ki2yxOC98DMxk6WZN9GLFOguCjBB/gr3Fzp7+
+VRvQTfYxIV/kZ7OGPrbOX2Sm+QZD/F7uDmSEuaWD2RRwiN9LFlc6ABM+dNLRtjmK
+JLuwKIc2AqbiZQxOuWf/+la8SBstg/xzsU0cLX43tD6b5AZajCylvU1RaxEkFBRb
+9kxQtMi9IpYS4RhL
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-demo-idp.switch.ch:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-demo-idp.switch.ch:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-demo-idp.switch.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-demo-idp.switch.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-demo-idp.switch.ch/idp/profile/SAML2/POST/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">aai-demo-idp.switch.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDODCCAiCgAwIBAgIJAK1/mY3/13x1MA0GCSqGSIb3DQEBBQUAMCExHzAdBgNV
+BAMTFmFhaS1kZW1vLWlkcC5zd2l0Y2guY2gwHhcNMTkwMzE1MDcyMzI0WhcNMjIw
+MzE0MDcyMzI0WjAhMR8wHQYDVQQDExZhYWktZGVtby1pZHAuc3dpdGNoLmNoMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr7tKI/3W0h5EO9/o7aB2A1HH
+yIo6zQjakCVCq/aQnzBzITpvC/SkJQQk6GvIul6t4J4J4vE2YRud6EGcQB1Qn2Oi
+hatWfIFT9DO4Zr9imVLA4V/q5CzCk9VX1lVhX9WEtnnrbdhU/iUpQw9B+N+iIDt9
+zjHMW5PS7QQ0Pl5aSJy8S5rH4mr2RILMPWq9UpUXuyCFv4WQ6CvngzhgfJSzH7VO
+2XV22jTlox5tAjguoaBOuFefMOjy1JCmMYSWWUG3qHDCfvAzIoFRvwI4N8IX22rh
+MN9TfKyyOaL+v1t4A+39rnjv8VcvWL0pJdOWFT34+YxII6Rodg0WuyiLfut62wID
+AQABo3MwcTBQBgNVHREESTBHghZhYWktZGVtby1pZHAuc3dpdGNoLmNohi1odHRw
+czovL2FhaS1kZW1vLWlkcC5zd2l0Y2guY2gvaWRwL3NoaWJib2xldGgwHQYDVR0O
+BBYEFNhlyhfnqzkYtuVcMrRAYtm2SJuTMA0GCSqGSIb3DQEBBQUAA4IBAQBsgcpL
+xRBBvFox/O23j32e1rHmYzYHXlDdFllbhQiwOxw3I5DvUAFmmC8TUvLRUBTSObwZ
+EjnztX2J0hcokkM+Tmvo4s5FTIgq0KQqQXmbmDhDg/5zx1lpp8c7u8zigc/YV2TT
+ekuCZ6Gb7GkjuZivrLMUMhMrdD9ki2yxOC98DMxk6WZN9GLFOguCjBB/gr3Fzp7+
+VRvQTfYxIV/kZ7OGPrbOX2Sm+QZD/F7uDmSEuaWD2RRwiN9LFlc6ABM+dNLRtjmK
+JLuwKIc2AqbiZQxOuWf/+la8SBstg/xzsU0cLX43tD6b5AZajCylvU1RaxEkFBRb
+9kxQtMi9IpYS4RhL
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-demo-idp.switch.ch:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-demo-idp.switch.ch:8443/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">aai-demo-idp.switch.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="de">AAI Demo Home Organisation</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="en">AAI Demo Home Organisation</OrganizationDisplayName>
+			<OrganizationURL xml:lang="de">http://www.aai-demo-idp.switch.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="en">http://www.aai-demo-idp.switch.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- ETH Zurich (BI test) -->
+	<md:EntityDescriptor entityID="https://aai-logon-bi-test.ethz.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor errorURL="http://www.id.ethz.ch/servicedesk" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">aai-logon-bi-test.ethz.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="de">ETH Zürich (BI test)</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="en">ETH Zurich (BI test)</mdui:DisplayName>
+					<mdui:Description xml:lang="de">Eidgenössische Technische Hochschule Zürich - test IDP für BI</mdui:Description>
+					<mdui:Description xml:lang="en">Swiss Federal Institute of Technology Zurich - test IDP for BI</mdui:Description>
+					<mdui:Logo height="16" width="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAASBQTFRFAD59Aj9+AT9+AD19ADh5ADd4ADp6AD18A0F/HleOJ12SJl2SJVuRIVmPIFiPJFuRIlmQFlCJBEF/H1iOBkOAA0B+ADV3OWub9vr80N7p0+Dq3ujw7vT48/f62+bv////bpG0MF+T9vv8ADl6ADF0apG09/r8YomvU3+oBESBuczcu83dD0yG+v39gaG/iqjE3ObuADt6mbPM5ezypr3SADN11uHreZq7F0yG/f7+wNHg+vz9o7vRAT99ADl50t/pzNrlc5i5N2maD0qFP2+dUn6o9Pn6Aj582ePsgKG/AC9zADx8CEWBl7TLsMbYx9fjTHmlFVCIrcXWEUuFVIGpjqzGBUOAor3RNmmZADZ4AkB+ADZ3ADR2AD99A0B/AT595RKpMgAAAAFiS0dEHwUNEL0AAAAJcEhZcwAADsMAAA7DAcdvqGQAAACjSURBVBjTY2AgCzBCARMDI5jPzMLKysrCwsrCxsDCDuJzcHJx8/Dy8QsICgmLsDOIiolLSEpJy8jKySsoKgkqMwipqKqpa2hqaevo6ukbGDIABYyMTfRNzcwtLK2sbUw5GGzt7B0cnZzlXVzd3D08vYQYvH18/fwDAoOCQ0LDwiMio4DWRJuqsDDHsLOJMcSwxYLcIRoXx8QQF88kyiDKRJbHADKiFN5zQY3pAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE1LTExLTExVDE1OjM4OjQ2KzAxOjAw/4hh9gAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNS0xMS0xMVQxNDo0MTowNyswMTowMKRQO8gAAAAadEVYdFNvZnR3YXJlAFBhaW50Lk5FVCB2My41LjEwMPRyoQAAAABJRU5ErkJggg==</mdui:Logo>
+					<mdui:Logo height="64" width="64">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwwAADsMBx2+oZAAAABp0RVh0U29mdHdhcmUAUGFpbnQuTkVUIHYzLjUuMTAw9HKhAAAGHklEQVRoQ+1ZfUxTVxSvi5uJbpLFZHEzRv8xZvixz8QsmxSL4jpEM4dxuhhgIhCnxkGmLvE9EESEaWQMcMAAK4MxYIIyBMenwIRBx7cgSmkFSsVSRCiU177X7bC2990CLR+NELP3ctK07917zvndc87vnLY8ngPxfMvz7T2cPgdgvjOQiwAXARtpkEshLoW4FJrvHOAiwEXAxhywcTvXB+Y7A7kIcBHgini+c4CLgNUI8InVByJdAjOetbhH/L5sfzhLiY7EanfWrk90Ps8lYHLCtE6jC5xIv59u/TMn15EfCxYKjF6+7nYhoaARmdXr9SHplbMB8Maei0mFTXPgP6PXv3U4Brm45sD3N6ofILs0TX90Ink2ANZ7xZTc7ZoDALK+wbWekcjFTV/FNT5UIrsURfGE5MwB8Iltp66q1BqkiGGYvyWPcmskpc2dluSPOilIp2qIZvRoo1pD1XX05td2FNbLDBuHKB1+LukV95a7fWd0kU+4kilahkEL5P2DPOdZAHAkXAJ+1lBapKiipcvB/8oa96h3fGJZ8cXe+8TafxljfzAmrqhpWGt0Ua9nGqWKfeez3vSMXu91eWyjb2xtTz8OIOKG+FXXUCMAR2JX8C/40yu3W3iOFsjGShEv/jj4eELhiI5Guo7FFfH40+gbjkT49Wq16YxphrlW2bp01znclljOAoDAelzIXugUaFgAdr9JKsIBeP2Qb9FPKwCW7Tx/Ob8Oygvp8k8s5m0hxjAIJgjejwSkqLhRZ8oBLc0kFDaMbURrtpKyp8NI7ejo6A4yeeyMYY2AWPn5xYIGGZ63Kz0jZgNgxd4LOTXt+EkoVU/uSHoVHYq7UlljayeIRPK4Va76LDTbzIAzmVnUoKeNSax8OuIbedNsgZDU6tgaAJKRqQblUiUoB+nrVFGm9APrQ1qd3R6z6JmpshIBe+9o5Qg1JQUBSfslFuF6NnrHVrZ2w33YC68PewdcyDR8AbTFKdWiBQ8H1K+4hsw8AnziA/8EvAAM3ky8dDqd3V5T/f2XJMLTqa3dKoMHsL61S7neJ5b1gE94RuaNA4DUTgQWnvXXoq1nZgzgRUHgKdFtKC+k8fHT4ap73VVtPbUSRfX9HvEDBUiDtLesSbpk11l8CjglKhkcNWYIlFBJSydvK0aCAqJKxnI8uC5XDVa3ySvvye+0dDd3KlHxGPAfi7uFOvQkMCwhW7TtzOW8OuQ9KApILX3bNw7S48PjSe8ejt90NAGE7y+Cmy9swf0jQ9LLKVMB6GgmvmB8BXcoB5Dm/iFNUGoZKNxwKBZESKSqNGzeUjS98QjboWcAYMknwTUdvSxR6OgNvlYVmRhm2e4wEVSwibs0lM4nKs+MfIUBqkGWgsTtis1fJyLPlrqGKLDW+WRUu8472trAZunZ0t3nYDMCMKzRbPCNGvMDmG6cmHcGaFUF9VIEQK3RColfcSsOJ0RD2BnfFEvWekShBXZuoagDgvU/2+Srv7g0GwBQlzTWAaBSK9q68+qlJTX1mdXtObUdWWJJXoP0Wk37Kg+MpPnEZr8kcfsjhBwO++XdZiToF1+owVgyJrfmJWEQcnFHUAYCD0pExU2vfRo2GwDAjDghgFIoxzFhGBhyDAIfKTW18RAWYkfC49L1AeyAe/tUZhW8hciplaAxCQae0MwKnhPb406KSvEWFppRaediuQlY/JeSTyQWTWuKhk63Ag1hDsQCAXk8OpcxURC4UtfVZ9aDnUnxfWOLgKcwbpxOLmXnHD7RPTSCAACJuwSmWJyCDFU3eXScyB61Bk4dHfbEN4aAwKwBEwdSYvj+APcN6+EiU8pxE1BajdJH6OmDnv6deI8TBgxQwFvG8PapNdu+vTrF9DU5gO1kSllzRnkzvFqStPJmkH1h2Yu3ByMly93CTyYVwn3DrsyK5veOJuAm3j8aH58vNjz9reJuRHbVuoNYBgoDkDlQcjatfNV+qxVsMQIwV0HrmY7AVIePcRM3jhuDYT2uFrIfJ7Fx253IqYdfawVu4w8ec7OdAzCN7zfPNBRcBLgI2JhgXApxKcSl0HznABcBLgI25oCN27k+MN8ZyEWAi8D/vIj/Ba3Wp82ObedLAAAAAElFTkSuQmCC</mdui:Logo>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>aai-logon-bi-test.ethz.ch</mdui:DomainHint>
+					<mdui:GeolocationHint>geo:47.37646,8.54792</mdui:GeolocationHint>
+					<mdui:GeolocationHint>geo:47.41039,8.50902</mdui:GeolocationHint>
+					<mdui:GeolocationHint>geo:47.566087,7.602298</mdui:GeolocationHint>
+					<mdui:GeolocationHint>geo:46.022244,8.916146</mdui:GeolocationHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIGlDCCBXygAwIBAgIUOH+INAl5nqX8PsQXGIlJS/2pcl4wDQYJKoZIhvcNAQEL
+BQAwTTELMAkGA1UEBhMCQk0xGTAXBgNVBAoTEFF1b1ZhZGlzIExpbWl0ZWQxIzAh
+BgNVBAMTGlF1b1ZhZGlzIEdsb2JhbCBTU0wgSUNBIEcyMB4XDTE5MDYxMTA3NTYz
+MloXDTIxMDYxMTA4MDYwMFowazELMAkGA1UEBhMCQ0gxEDAOBgNVBAgMB1p1ZXJp
+Y2gxEDAOBgNVBAcMB1p1ZXJpY2gxFDASBgNVBAoMC0VUSCBadWVyaWNoMSIwIAYD
+VQQDDBlhYWktbG9nb24tYmktdGVzdC5ldGh6LmNoMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEApKF1HlMqJJYOIXVjXBvm6z64dn6Ypbk2RSSDc/OhX37S
+0D9b3RwuDi2w88tbZXpf8H1Nu+q3UqIjIOSSYqZhY+jbPLtsSwPKS4WfzRo6mvJj
+9kZT9GSnlHwto018TibzzM0z85uNQg0kcJ6hsADttNBxz+9iGNtJ0z6h9nnw1F2X
+5Ejavilgrved0Ej2ESnLudDwHO/E+sZNT3XExnGPb+13muTosMCMCRW9PaGjCokA
+5X2jjDcl+Uwk1doh88mKP1LoT9v9Fmw2hgguDVoy89X/TiBx7rDOzZ/1DsLr0Sjy
+WL+k8EycFOHvW9AlvcUvmb5h4Fo9Fdjj2iMps9KIRQIDAQABo4IDTDCCA0gwCQYD
+VR0TBAIwADAfBgNVHSMEGDAWgBSRGWKtWxenMPvw3jklsb2MubhRJzBzBggrBgEF
+BQcBAQRnMGUwNwYIKwYBBQUHMAKGK2h0dHA6Ly90cnVzdC5xdW92YWRpc2dsb2Jh
+bC5jb20vcXZzc2xnMi5jcnQwKgYIKwYBBQUHMAGGHmh0dHA6Ly9vY3NwLnF1b3Zh
+ZGlzZ2xvYmFsLmNvbTBGBgNVHREEPzA9ghlhYWktbG9nb24tYmktdGVzdC5ldGh6
+LmNogg92a3VuZ2Z1LmV0aHouY2iCD3ZraWt1eXUuZXRoei5jaDBRBgNVHSAESjBI
+MEYGDCsGAQQBvlgAAmQBATA2MDQGCCsGAQUFBwIBFihodHRwOi8vd3d3LnF1b3Zh
+ZGlzZ2xvYmFsLmNvbS9yZXBvc2l0b3J5MB0GA1UdJQQWMBQGCCsGAQUFBwMCBggr
+BgEFBQcDATA6BgNVHR8EMzAxMC+gLaArhilodHRwOi8vY3JsLnF1b3ZhZGlzZ2xv
+YmFsLmNvbS9xdnNzbGcyLmNybDAdBgNVHQ4EFgQUmYJkDE86PD0nqkNjvkWbHTg9
+G+EwDgYDVR0PAQH/BAQDAgWgMIIBfgYKKwYBBAHWeQIEAgSCAW4EggFqAWgAdwCk
+uQmQtBhYFIe7E6LMZ3AKPDWYBPkb37jjd80OyA3cEAAAAWtFkwtwAAAEAwBIMEYC
+IQCooPyiyL2Dg73PUIYfrOCjZzfW/+wtAxPwW6CGDf3a9gIhAPMN2iVhad7NmykE
+UVDik3dBU6wV1/L7pDi2fCLBMXMSAHYAVhQGmi/XwuzT9eG9RLI+x0Z2ubyZEVzA
+75SYVdaJ0N0AAAFrRZMLoAAABAMARzBFAiB289POYDwLJoZQ+MUCW00TWdpN389/
+H/IOWzYFAi5R4wIhAOi/xvq4i0w2Tm4GyT32Je9a+W+LqEjtZiSo1lq7GIP4AHUA
+b1N2rDHwMRnYmQCkURX/dxUcEdkCwQApBo2yCJo32RMAAAFrRZMMdgAABAMARjBE
+AiB6InNr7MgzmeRvaZ22T+NylP6731iFB2mgR6VQ4tDZKAIgfFo1FPvnw+E/3Qg8
+hI6w46Pw+o1hNmy+qFVN/YIs25wwDQYJKoZIhvcNAQELBQADggEBAEaBiKWWYZyh
+W4pg1saIj+FvhYRW/i/lWhxCW/B99UwvglshdY3I3cuDnuU9tTXyXeyL8OYsbfQP
+S6n91NP5lmFPuW4njbbtJr5lV1C3KJI4h9wj20w16QiSO/H9u5hv/Rq8QzL4SK7H
+cR6mjZ/YQcLPZmB1u3saUtdm3Tqau5NHCSgQjFY3B5/HQarmjPUPKu577CYMBM8v
+1vh5it0mDCyxVIIhiwdMDesV3EMP3S1rhuhshmh4SwWCZJerghckzmvljAM6cOJA
+S82amplIMn8jK6xATjRGWBGHpOFAaLjYQKckM30xPMpAcuatnardU2dpNlBeD+F4
+Nc+ngn1OAVc=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">aai-logon-bi-test.ethz.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIGlDCCBXygAwIBAgIUOH+INAl5nqX8PsQXGIlJS/2pcl4wDQYJKoZIhvcNAQEL
+BQAwTTELMAkGA1UEBhMCQk0xGTAXBgNVBAoTEFF1b1ZhZGlzIExpbWl0ZWQxIzAh
+BgNVBAMTGlF1b1ZhZGlzIEdsb2JhbCBTU0wgSUNBIEcyMB4XDTE5MDYxMTA3NTYz
+MloXDTIxMDYxMTA4MDYwMFowazELMAkGA1UEBhMCQ0gxEDAOBgNVBAgMB1p1ZXJp
+Y2gxEDAOBgNVBAcMB1p1ZXJpY2gxFDASBgNVBAoMC0VUSCBadWVyaWNoMSIwIAYD
+VQQDDBlhYWktbG9nb24tYmktdGVzdC5ldGh6LmNoMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEApKF1HlMqJJYOIXVjXBvm6z64dn6Ypbk2RSSDc/OhX37S
+0D9b3RwuDi2w88tbZXpf8H1Nu+q3UqIjIOSSYqZhY+jbPLtsSwPKS4WfzRo6mvJj
+9kZT9GSnlHwto018TibzzM0z85uNQg0kcJ6hsADttNBxz+9iGNtJ0z6h9nnw1F2X
+5Ejavilgrved0Ej2ESnLudDwHO/E+sZNT3XExnGPb+13muTosMCMCRW9PaGjCokA
+5X2jjDcl+Uwk1doh88mKP1LoT9v9Fmw2hgguDVoy89X/TiBx7rDOzZ/1DsLr0Sjy
+WL+k8EycFOHvW9AlvcUvmb5h4Fo9Fdjj2iMps9KIRQIDAQABo4IDTDCCA0gwCQYD
+VR0TBAIwADAfBgNVHSMEGDAWgBSRGWKtWxenMPvw3jklsb2MubhRJzBzBggrBgEF
+BQcBAQRnMGUwNwYIKwYBBQUHMAKGK2h0dHA6Ly90cnVzdC5xdW92YWRpc2dsb2Jh
+bC5jb20vcXZzc2xnMi5jcnQwKgYIKwYBBQUHMAGGHmh0dHA6Ly9vY3NwLnF1b3Zh
+ZGlzZ2xvYmFsLmNvbTBGBgNVHREEPzA9ghlhYWktbG9nb24tYmktdGVzdC5ldGh6
+LmNogg92a3VuZ2Z1LmV0aHouY2iCD3ZraWt1eXUuZXRoei5jaDBRBgNVHSAESjBI
+MEYGDCsGAQQBvlgAAmQBATA2MDQGCCsGAQUFBwIBFihodHRwOi8vd3d3LnF1b3Zh
+ZGlzZ2xvYmFsLmNvbS9yZXBvc2l0b3J5MB0GA1UdJQQWMBQGCCsGAQUFBwMCBggr
+BgEFBQcDATA6BgNVHR8EMzAxMC+gLaArhilodHRwOi8vY3JsLnF1b3ZhZGlzZ2xv
+YmFsLmNvbS9xdnNzbGcyLmNybDAdBgNVHQ4EFgQUmYJkDE86PD0nqkNjvkWbHTg9
+G+EwDgYDVR0PAQH/BAQDAgWgMIIBfgYKKwYBBAHWeQIEAgSCAW4EggFqAWgAdwCk
+uQmQtBhYFIe7E6LMZ3AKPDWYBPkb37jjd80OyA3cEAAAAWtFkwtwAAAEAwBIMEYC
+IQCooPyiyL2Dg73PUIYfrOCjZzfW/+wtAxPwW6CGDf3a9gIhAPMN2iVhad7NmykE
+UVDik3dBU6wV1/L7pDi2fCLBMXMSAHYAVhQGmi/XwuzT9eG9RLI+x0Z2ubyZEVzA
+75SYVdaJ0N0AAAFrRZMLoAAABAMARzBFAiB289POYDwLJoZQ+MUCW00TWdpN389/
+H/IOWzYFAi5R4wIhAOi/xvq4i0w2Tm4GyT32Je9a+W+LqEjtZiSo1lq7GIP4AHUA
+b1N2rDHwMRnYmQCkURX/dxUcEdkCwQApBo2yCJo32RMAAAFrRZMMdgAABAMARjBE
+AiB6InNr7MgzmeRvaZ22T+NylP6731iFB2mgR6VQ4tDZKAIgfFo1FPvnw+E/3Qg8
+hI6w46Pw+o1hNmy+qFVN/YIs25wwDQYJKoZIhvcNAQELBQADggEBAEaBiKWWYZyh
+W4pg1saIj+FvhYRW/i/lWhxCW/B99UwvglshdY3I3cuDnuU9tTXyXeyL8OYsbfQP
+S6n91NP5lmFPuW4njbbtJr5lV1C3KJI4h9wj20w16QiSO/H9u5hv/Rq8QzL4SK7H
+cR6mjZ/YQcLPZmB1u3saUtdm3Tqau5NHCSgQjFY3B5/HQarmjPUPKu577CYMBM8v
+1vh5it0mDCyxVIIhiwdMDesV3EMP3S1rhuhshmh4SwWCZJerghckzmvljAM6cOJA
+S82amplIMn8jK6xATjRGWBGHpOFAaLjYQKckM30xPMpAcuatnardU2dpNlBeD+F4
+Nc+ngn1OAVc=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon-bi-test.ethz.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">aai-logon-bi-test.ethz.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="de">ETH Zürich (BI test)</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="en">ETH Zurich (BI test)</OrganizationDisplayName>
+			<OrganizationURL xml:lang="de">http://www.aai-logon-bi-test.ethz.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="en">http://www.aai-logon-bi-test.ethz.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- HES-SO Test IdP -->
+	<md:EntityDescriptor entityID="https://aai-logon-test.hes-so.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">aai-logon-test.hes-so.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">HES-SO Test IdP</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="fr">HES-SO Test IdP</mdui:DisplayName>
+					<mdui:Description xml:lang="en">HES-SO Test IdP</mdui:Description>
+					<mdui:Description xml:lang="fr">HES-SO Test IdP</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>aai-logon-test.hes-so.ch</mdui:DomainHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDTDCCAjSgAwIBAgIVAJoQJef8IL8GF2ZrpsFWOXe1Z5fDMA0GCSqGSIb3DQEB
+CwUAMCMxITAfBgNVBAMMGGFhaS1sb2dvbi10ZXN0Lmhlcy1zby5jaDAeFw0xODAx
+MTIxMDI2MTdaFw0yMTAxMTIxMDI2MTdaMCMxITAfBgNVBAMMGGFhaS1sb2dvbi10
+ZXN0Lmhlcy1zby5jaDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALAI
+pYpTa4/Tb+Ylm258/wUuH/y7qtaFFRoKi5bbsH8SQXkJwGyZI67nBSz4HBRK2awU
+g2OOuA7G76xxfRxiyDVYm76pMbCAJeNmeQWakyvrIrGSOpwMs68tbxqsVUBIzjiF
+t3c2Xsj+SMQBwHBWJxVKxlbqT64GslIWKIbdlBKv+UBCwtscYzw70lj68b1g6l/d
+bF8OMDdNTooTwfs0xjVR/gq/k3W5hxHU7MKcDpHKU3XXW3yig/Ta829AqHsAgyDn
+yYHKCxGLDDWG1cDvYk4wlryXPYH+7XRaUW8vg1WaAm70QXQOJoxrJQwsQIlz/rN6
+w2LL94CILvQ1hH7ox7MCAwEAAaN3MHUwHQYDVR0OBBYEFDxLWLFAc2yVuZZJ5j+8
+l9TlDfTmMFQGA1UdEQRNMEuCGGFhaS1sb2dvbi10ZXN0Lmhlcy1zby5jaIYvaHR0
+cHM6Ly9hYWktbG9nb24tdGVzdC5oZXMtc28uY2gvaWRwL3NoaWJib2xldGgwDQYJ
+KoZIhvcNAQELBQADggEBAA/0tIVPwZ8yQT7QUzqVwz8x7LlrHdlLjoI0kOGA+hw8
+2EjPO+aMmB/GU0E3YU1Ejw4w2Vzxjm+b3Qgi1M6b6ftb9MlOH78bxgOdUM4KtgBt
+cF7NlhJNxTjV2BsBOCenmJoUJlVK08/mb/xwsExMQc7mmVm7Eo2nQb+MYwf7fiet
+qLz+8g39WKLTGMNs9rzAFzWCRLJkBqnA+sZi+/wU6x8mDgtmxgNErBHCLWFuc2rf
+yIjEdB67LkSbGlrCa0glLGKZFnAqEXxgKGgFLOZS0dZhGf0byWcVLjLtfoM8ntyN
+/V6yYepaTfnhkVsSWCNiFPzfTH58ZDZMxoBBRLsif2U=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon-test.hes-so.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">aai-logon-test.hes-so.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDTDCCAjSgAwIBAgIVAJoQJef8IL8GF2ZrpsFWOXe1Z5fDMA0GCSqGSIb3DQEB
+CwUAMCMxITAfBgNVBAMMGGFhaS1sb2dvbi10ZXN0Lmhlcy1zby5jaDAeFw0xODAx
+MTIxMDI2MTdaFw0yMTAxMTIxMDI2MTdaMCMxITAfBgNVBAMMGGFhaS1sb2dvbi10
+ZXN0Lmhlcy1zby5jaDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALAI
+pYpTa4/Tb+Ylm258/wUuH/y7qtaFFRoKi5bbsH8SQXkJwGyZI67nBSz4HBRK2awU
+g2OOuA7G76xxfRxiyDVYm76pMbCAJeNmeQWakyvrIrGSOpwMs68tbxqsVUBIzjiF
+t3c2Xsj+SMQBwHBWJxVKxlbqT64GslIWKIbdlBKv+UBCwtscYzw70lj68b1g6l/d
+bF8OMDdNTooTwfs0xjVR/gq/k3W5hxHU7MKcDpHKU3XXW3yig/Ta829AqHsAgyDn
+yYHKCxGLDDWG1cDvYk4wlryXPYH+7XRaUW8vg1WaAm70QXQOJoxrJQwsQIlz/rN6
+w2LL94CILvQ1hH7ox7MCAwEAAaN3MHUwHQYDVR0OBBYEFDxLWLFAc2yVuZZJ5j+8
+l9TlDfTmMFQGA1UdEQRNMEuCGGFhaS1sb2dvbi10ZXN0Lmhlcy1zby5jaIYvaHR0
+cHM6Ly9hYWktbG9nb24tdGVzdC5oZXMtc28uY2gvaWRwL3NoaWJib2xldGgwDQYJ
+KoZIhvcNAQELBQADggEBAA/0tIVPwZ8yQT7QUzqVwz8x7LlrHdlLjoI0kOGA+hw8
+2EjPO+aMmB/GU0E3YU1Ejw4w2Vzxjm+b3Qgi1M6b6ftb9MlOH78bxgOdUM4KtgBt
+cF7NlhJNxTjV2BsBOCenmJoUJlVK08/mb/xwsExMQc7mmVm7Eo2nQb+MYwf7fiet
+qLz+8g39WKLTGMNs9rzAFzWCRLJkBqnA+sZi+/wU6x8mDgtmxgNErBHCLWFuc2rf
+yIjEdB67LkSbGlrCa0glLGKZFnAqEXxgKGgFLOZS0dZhGf0byWcVLjLtfoM8ntyN
+/V6yYepaTfnhkVsSWCNiFPzfTH58ZDZMxoBBRLsif2U=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon-test.hes-so.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">aai-logon-test.hes-so.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">HES-SO Test IdP</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="fr">HES-SO Test IdP</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.aai-logon-test.hes-so.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="fr">http://www.aai-logon-test.hes-so.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- HUG Idp TEST -->
+	<md:EntityDescriptor entityID="https://aai-test.hcuge.ch/idp">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">aai-test.hcuge.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">HUG Test IdP</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="fr">HUG Idp TEST</mdui:DisplayName>
+					<mdui:Description xml:lang="en">Test IdP of Hôpitaux universitaires de Genève</mdui:Description>
+					<mdui:Description xml:lang="fr">Service d'authentification AAI des Hôpitaux universtaires de Genève</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:IPHint>129.195.0.0/16</mdui:IPHint>
+					<mdui:DomainHint>hcuge.ch</mdui:DomainHint>
+					<mdui:GeolocationHint>geo:46.19383,6.14882</mdui:GeolocationHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIHFTCCBf2gAwIBAgIUH4uefxD7fBsq8VMgg1h/ztoGidUwDQYJKoZIhvcNAQEL
+BQAwTTELMAkGA1UEBhMCQk0xGTAXBgNVBAoTEFF1b1ZhZGlzIExpbWl0ZWQxIzAh
+BgNVBAMTGlF1b1ZhZGlzIEdsb2JhbCBTU0wgSUNBIEcyMB4XDTE4MDcyMzA2NTEz
+M1oXDTIwMDcyMzA3MDAwMFowdzELMAkGA1UEBhMCQ0gxDzANBgNVBAgMBkdlbmV2
+ZTEPMA0GA1UEBwwGR2VuZXZlMSowKAYDVQQKDCFIb3BpdGF1eCB1bml2ZXJzaXRh
+aXJlcyBkZSBHZW5ldmUxGjAYBgNVBAMMEWFhaS10ZXN0LmhjdWdlLmNoMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPlJibpYaaGjQjnMHjMFxn1IWHjO
+vXljbml2UzwtWhdFSA+jOlnhznJ9i8XyTuuuD41ORRPKR7HTeCYb/sfKGjHn42j6
+Ejy9Vo+U5g50EGPIvmVvSJsAo0d+20ryUwO2+3XWWNJHvlqFlCiCTklmMjWcRcMk
+jGJnmKn1pOjXXttYmMgxCvmWA6WGF2xkegwsjZRnCIq7eFm7zSEVe7PK6UGSNuZm
+0ylp5QgKxSxSa2n7N9rk1j1wSGHiWHb95NWpE9iANAsWjijuauivG6Qo9WVKlxfr
+Z3XKiRmFOU8y48v6H7HIdiTyh7u/emJlilTrm7gxUzHwnmVidAAuVQrsSwIDAQAB
+o4IDwTCCA70wCQYDVR0TBAIwADAfBgNVHSMEGDAWgBSRGWKtWxenMPvw3jklsb2M
+ubhRJzBzBggrBgEFBQcBAQRnMGUwNwYIKwYBBQUHMAKGK2h0dHA6Ly90cnVzdC5x
+dW92YWRpc2dsb2JhbC5jb20vcXZzc2xnMi5jcnQwKgYIKwYBBQUHMAGGHmh0dHA6
+Ly9vY3NwLnF1b3ZhZGlzZ2xvYmFsLmNvbTBEBgNVHREEPTA7ghFhYWktdGVzdC5o
+Y3VnZS5jaIIRc2N0LWZvcm0uaGN1Z2UuY2iCE2VraWRzLXRlc3QuaGN1Z2UuY2gw
+UQYDVR0gBEowSDBGBgwrBgEEAb5YAAJkAQEwNjA0BggrBgEFBQcCARYoaHR0cDov
+L3d3dy5xdW92YWRpc2dsb2JhbC5jb20vcmVwb3NpdG9yeTAdBgNVHSUEFjAUBggr
+BgEFBQcDAgYIKwYBBQUHAwEwOgYDVR0fBDMwMTAvoC2gK4YpaHR0cDovL2NybC5x
+dW92YWRpc2dsb2JhbC5jb20vcXZzc2xnMi5jcmwwHQYDVR0OBBYEFBPBBs7BF0OG
+JefLCY93KYr8CCkSMA4GA1UdDwEB/wQEAwIFoDCCAfUGCisGAQQB1nkCBAIEggHl
+BIIB4QHfAHYApLkJkLQYWBSHuxOizGdwCjw1mAT5G9+443fNDsgN3BAAAAFkxfCm
+cwAABAMARzBFAiEA0YCTCsPCzVkib3VYGOfzYn5Kr5GtEvn+7yz/4WYYSgECIFKL
+62OOedrdpLZKz2RJ0ZQHCsUVm0xnxt68Fv89cJV+AHYAu9nfvB+KcbWTlCOXqpJ7
+RzhXlQqrUugakJZkNo4e0YUAAAFkxfCmTQAABAMARzBFAiEAzI/MtRoK3b8/s43I
+SXcV8HJHipAPCBcYPijxOf7p7qACIA8szKfxH+jXraCA9k+R46sqBPQuxHqTUurG
+sa+9TyXIAHYAVhQGmi/XwuzT9eG9RLI+x0Z2ubyZEVzA75SYVdaJ0N0AAAFkxfCn
+rQAABAMARzBFAiEAhQFDotBkmMna7OFQKzOw5EQZTkYavKXFkjMR854rp9ICIHXk
+yFuc+LjMYP64tcndJ5mO+WrW96SYvK8EB2d8lEXEAHUAb1N2rDHwMRnYmQCkURX/
+dxUcEdkCwQApBo2yCJo32RMAAAFkxfCoeQAABAMARjBEAiBBAC3B6aDhlKhtMjSB
+o1Y1UjxxQ1ZH3odV0kr4UJmFZgIgcUlCYAhsoQJXD0K5qtpNrW77CiS6eoB+xViR
+hIxgINUwDQYJKoZIhvcNAQELBQADggEBABhjBgNI6bLT5stsquawmcbkKjvK8KD4
+RJ+3NqgKmLNiaS8bKyGsvQj+qJ11kD2rtdLCbi6VdfgK+aj5D93stCFCthQm1Mph
+kz0olIYW2Zw6E6wN5hIjJVcdBBt7FuMBNyavCRmzW07Z568koBJNQJi19JBIJjFV
+q7d24P8zKp7s6F/DsDPfNdUBKPQVJ7xrTEItFCPHf0qEjfsWb3nhUYE12/3VzteH
+a1oLA25R+SSx9x3c3AwNzRByoW7HfR7SaINGhlv8z/xiFDQm53x0IOCWA1EeKozQ
+0xtRAchma9qiAFYKiKRSzPdUxNSEdBPGUStgxlUPOhTIhyGvKJY32yA=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-test.hcuge.ch/saml/idp/profile/redirect/sls"/>
+			<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-test.hcuge.ch/saml/idp/profile/post/sls"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-test.hcuge.ch/saml/idp/profile/redirectorpost/sso"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-test.hcuge.ch/saml/idp/profile/redirectorpost/sso"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-test.hcuge.ch/saml/idp/profile/ecp/sso"/>
+		</md:IDPSSODescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">aai-test.hcuge.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">HUG Test IdP</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="fr">HUG Idp TEST</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.aai-test.hcuge.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="fr">http://www.aai-test.hcuge.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- FHNW-DEV - Fachhochschule Nordwestschweiz -->
+	<md:EntityDescriptor entityID="https://aai-logon.dev.fhnw.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">dev.fhnw.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">FHNW-DEV - Fachhochschule Nordwestschweiz</mdui:DisplayName>
+					<mdui:Description xml:lang="en">FHNW-DEV IdP of: dev.fhnw.ch</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDQDCCAiigAwIBAgIVAPXjjW6kZV2N8A8++cGKvwGWGs1HMA0GCSqGSIb3DQEB
+CwUAMCAxHjAcBgNVBAMMFWFhaS1sb2dvbi5kZXYuZmhudy5jaDAeFw0xNzAzMTQx
+MDI1MTZaFw0yMDAzMTQxMDI1MTZaMCAxHjAcBgNVBAMMFWFhaS1sb2dvbi5kZXYu
+Zmhudy5jaDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKJ6LBB929f/
+csQx9X7EhGbz6WbvF6n2lP0xbeHmKuVX5pDyd7g6Rc4d7Oscl8OdFUAdTh1xT3Wa
+CBJfeuq/rgLKky6T82iBDXJ6ugQlHXITfXLASHU5NCKx5oXXbwRGcWlhpjyfLcmB
+c4VacyKhMQE6y49MyDjP1nDNLNPbA+uLGjOgmHz5RVSyWuptal8HKdHlQhGkrX3H
+UL/h8/SNYMGfhkxBC8tmA2yO0khODqbMp0mZ25G4RcNqqSVLucfAEcLKEe2v5z63
+BPqJo1vULffSgEUve65ztyVul4NZ2eiJ6Tm1uMdGAyjixOexMeWk7SwOuWaopOPC
+IYx310iXPcECAwEAAaNxMG8wHQYDVR0OBBYEFGnTdEsafY1ynJi548LiRLdZZlop
+ME4GA1UdEQRHMEWCFWFhaS1sb2dvbi5kZXYuZmhudy5jaIYsaHR0cHM6Ly9hYWkt
+bG9nb24uZGV2LmZobncuY2gvaWRwL3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQAD
+ggEBAA1hVdtjEAR94Drb0g5Eq6KxcqjRItF7A0mdHkTKTC4CxTmLOhVa0g2bIqNi
+RhZmzoJ22lJa7oOtJcvJ6XNSANRYd9P9F8Dvz5TQKxccIEJOWei9ULrG7dPt0hTv
+hd6FahEh7A8iHSBbUh68kktZM9JrokDz5ARSDxrtc0gEU8j5/6IGqhhPnyd7qIp8
+KsQLetWmz2BIj0pDMhTJPy6mrqvPPXDUXyqPyGNQdAriiZB85g3+7+87NJ1sh7ke
+zZCxr5afAFoSIcu5KuFIPx+w1isJ3gKn21zP9+kGXWiSUCYEi9m28SOKOH1sBw0g
+CG9Wz9KLfaxssPHaavd96MVteM8=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon.dev.fhnw.ch/shibboleth-idp/Artifact" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon.dev.fhnw.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon.dev.fhnw.ch/shibboleth-idp/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon.dev.fhnw.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon.dev.fhnw.ch/idp/profile/SAML2/POST/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">dev.fhnw.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDQDCCAiigAwIBAgIVAPXjjW6kZV2N8A8++cGKvwGWGs1HMA0GCSqGSIb3DQEB
+CwUAMCAxHjAcBgNVBAMMFWFhaS1sb2dvbi5kZXYuZmhudy5jaDAeFw0xNzAzMTQx
+MDI1MTZaFw0yMDAzMTQxMDI1MTZaMCAxHjAcBgNVBAMMFWFhaS1sb2dvbi5kZXYu
+Zmhudy5jaDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKJ6LBB929f/
+csQx9X7EhGbz6WbvF6n2lP0xbeHmKuVX5pDyd7g6Rc4d7Oscl8OdFUAdTh1xT3Wa
+CBJfeuq/rgLKky6T82iBDXJ6ugQlHXITfXLASHU5NCKx5oXXbwRGcWlhpjyfLcmB
+c4VacyKhMQE6y49MyDjP1nDNLNPbA+uLGjOgmHz5RVSyWuptal8HKdHlQhGkrX3H
+UL/h8/SNYMGfhkxBC8tmA2yO0khODqbMp0mZ25G4RcNqqSVLucfAEcLKEe2v5z63
+BPqJo1vULffSgEUve65ztyVul4NZ2eiJ6Tm1uMdGAyjixOexMeWk7SwOuWaopOPC
+IYx310iXPcECAwEAAaNxMG8wHQYDVR0OBBYEFGnTdEsafY1ynJi548LiRLdZZlop
+ME4GA1UdEQRHMEWCFWFhaS1sb2dvbi5kZXYuZmhudy5jaIYsaHR0cHM6Ly9hYWkt
+bG9nb24uZGV2LmZobncuY2gvaWRwL3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQAD
+ggEBAA1hVdtjEAR94Drb0g5Eq6KxcqjRItF7A0mdHkTKTC4CxTmLOhVa0g2bIqNi
+RhZmzoJ22lJa7oOtJcvJ6XNSANRYd9P9F8Dvz5TQKxccIEJOWei9ULrG7dPt0hTv
+hd6FahEh7A8iHSBbUh68kktZM9JrokDz5ARSDxrtc0gEU8j5/6IGqhhPnyd7qIp8
+KsQLetWmz2BIj0pDMhTJPy6mrqvPPXDUXyqPyGNQdAriiZB85g3+7+87NJ1sh7ke
+zZCxr5afAFoSIcu5KuFIPx+w1isJ3gKn21zP9+kGXWiSUCYEi9m28SOKOH1sBw0g
+CG9Wz9KLfaxssPHaavd96MVteM8=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon.dev.fhnw.ch/shibboleth-idp/AA"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon.dev.fhnw.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">dev.fhnw.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">FHNW-DEV - Fachhochschule Nordwestschweiz</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.dev.fhnw.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- Bootstrapped Home Organization e-xpertsolutions.com -->
+	<md:EntityDescriptor entityID="https://fedauth.e-xpertsolutions.com">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">e-xpertsolutions.com</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">Bootstrapped Home Organization e-xpertsolutions.com</mdui:DisplayName>
+					<mdui:Description xml:lang="en">Bootstrapped IdP of: e-xpertsolutions.com</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIEQTCCAqmgAwIBAgIJAKDaaO97rdppMA0GCSqGSIb3DQEBCwUAMCcxJTAjBgNV
+BAMTHGZlZGF1dGguZS14cGVydHNvbHV0aW9ucy5jb20wHhcNMTgwMjA4MTQyNzI3
+WhcNMjEwMjA4MTQyNzI3WjAnMSUwIwYDVQQDExxmZWRhdXRoLmUteHBlcnRzb2x1
+dGlvbnMuY29tMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAnh6/yuch
+QYXVYSAk5bf3zA3KpO0DXG3L8/5zVoh1GX5Loluvdjxyk+yn521q0jlSeDHOLQPN
+p01Lg0hwM0OpxEK3FCKXfbWkCS1DfZjlAKet3iGnbDOhKxzFxX1qMgINCQ4DF5bh
+TVADrgjQg5kY9ZHCgKloJChFZMfm1MX56NvywcKdyUDPrJiZEpd2dqKbCQfhbbsq
+VwzQ5oRWoyUqM5zbzguWCG2qe3baNvzNIQvvK9CGOC51x1RsY9As7qGRLqd2VPyL
+zQQ5dEh9M/8dyKws3WjOD/O+Nsa8gZO3PlHPbkb6fBrE8T6RcFLeiFd7nFO6tkJj
++YzCh2+rlhSfG6DUsyJLuoW+7rOocX0QmAc9ZiUjmMWLFv2wi1+RVKTKL8cb0XR5
+5nmuXD/byM6TZWXeM0SJiG9uP1ntz79IPWfZAhVGEVRArfJfyHLqSQSVxV/x3huc
+N7yfkH4Qj0HzDhOkS0/lFTy2l8BDwYEX4COJeYUl03e2fn1chEyxsZcbAgMBAAGj
+cDBuME0GA1UdEQRGMESCHGZlZGF1dGguZS14cGVydHNvbHV0aW9ucy5jb22GJGh0
+dHBzOi8vZmVkYXV0aC5lLXhwZXJ0c29sdXRpb25zLmNvbTAdBgNVHQ4EFgQU+p75
+IzX6x5ly15lzCN0VKkQhOBkwDQYJKoZIhvcNAQELBQADggGBAHpgkuwYCBAz5Rb9
+m3tPlCCxA3IO7ksEMI6Km9qVlO8UxX3SKXSXTgypueDgykyn1xl9X6evPtDkKwWY
+bqyj2+yUdJlZc99tBy7wbulFA7yOejQzdSVevGFxakCHRCVWzzdYskPaGGCTbNql
+Iuzxn3pxJBpm+z4QHwBPk3l5ERP8U74TaGQJsyMjla/0aalYFzj7Zn1moMZvmcCM
+h2Hm6Jx2d4yTxixZ/HXT6k72AcRySOg4fkzYj7UIEzAmQqCcxxqjoRAFhwBCl9Ed
+bmC3Smkwcg8q9ltRhxvwSgN+6MCRi6Blo7AGwEmoxUzOrqfXz+e/nuH+5HzsTVBC
+wQS8rOBb1fzu5BoRB9dUUfMhUeak2J+uilZPNIC1Yus0IoiO6iB13LJwxDjBmpTS
+xnVBKafS+Iib/2i+V7IgSivJOwlnVQM+tUxecSIptzIK+rDUr/fWuAv46D131og7
+JNnDUuUfZAZMhvke/Df73gMbaQ3zQmwe9UhYggnwutBDf6PlDQ==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://fedauth.e-xpertsolutions.com/saml/idp/profile/redirectorpost/sso"/>
+		</md:IDPSSODescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">e-xpertsolutions.com</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">Bootstrapped Home Organization e-xpertsolutions.com</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.e-xpertsolutions.com/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- Graduate Institute - Test IdP -->
+	<md:EntityDescriptor entityID="https://idp-dev.graduateinstitute.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				   
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:assurance-certification" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>https://refeds.org/sirtfi</saml:AttributeValue>
+				</saml:Attribute>
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">graduateinstitute.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">Graduate Institute - Test IdP</mdui:DisplayName>
+					<mdui:Description xml:lang="en">Test IdP of the Graduate Institute of International and Development Studies</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:GeolocationHint>geo:46.22097,6.14375</mdui:GeolocationHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDXDCCAkSgAwIBAgIVANreykP/e/4Da1JE46x4qdTlxNVuMA0GCSqGSIb3DQEB
+CwUAMCcxJTAjBgNVBAMMHGlkcC1kZXYuZ3JhZHVhdGVpbnN0aXR1dGUuY2gwHhcN
+MTgwMzEzMTYyMjMzWhcNMjEwMzEzMTYyMjMzWjAnMSUwIwYDVQQDDBxpZHAtZGV2
+LmdyYWR1YXRlaW5zdGl0dXRlLmNoMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEAqXoKQDS+eCpGgNRrBEeqto7tHYNswCJkUtE7MMlVmhyJeaS7ziJQLm/q
+3ToGKvx3ljWpgT3+hqmYYzHQw17e1b9a5zsO95hGntvkEGsJfghGOhc+VRv8y7ME
+OdMgKhgCMKZ58xIuOGlOP1fbSJYKrlvYcdzSJJF98iHfzS6geklpkzqxLSEGl8jX
+trlaLnAr0nCkNYfqkgGaEq+8r7VM49ihb0/c9IIC/8Z6tQ8NCvG7OjUyPucKFzo1
+g2LOwDY1qjwVJzIFeiny5+pZsZmBICakvXQKt2Qog19WxbaeY9moug6ZeRBaVE2S
+xwqQVqeOuae8Y1IsisQA0shzBx9mFQIDAQABo38wfTAdBgNVHQ4EFgQUeLd8Dxow
+k2tlGeVz5paTfInqkvUwXAYDVR0RBFUwU4IcaWRwLWRldi5ncmFkdWF0ZWluc3Rp
+dHV0ZS5jaIYzaHR0cHM6Ly9pZHAtZGV2LmdyYWR1YXRlaW5zdGl0dXRlLmNoL2lk
+cC9zaGliYm9sZXRoMA0GCSqGSIb3DQEBCwUAA4IBAQCmkolHwzkTI8s6l7WTYpwE
+zOQ/8smWjN/ShepPtcpPIzAX3ZRKX4kdUP7yGkUEvxuvL/1O5d8qrF4ee7Jp0tng
+4o5+5tCygpk7bsvdhYEDddx/Ep1TJNIz2xfCipEWd+SB+aTu15rbzwBdvvF7/jKW
+3h12dpgtZqwJ8rtsscuEcqrAa599sGbjwhSIPO+Bydj3cCtPfy/c5GBVlFvV6uzW
+pa1lQomsWHiCP19hC2za2mWHu/WdtcLLphdA3t2K6+dmR9WX6O8YzcSyk6gLtZF9
+74o5L2zKETULoRmGqZ3OrRbkhHzEvPDP1vd4gYQL4ZLZtOXW/VbaS/6uWjoxBOdy
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="1"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">graduateinstitute.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDXDCCAkSgAwIBAgIVANreykP/e/4Da1JE46x4qdTlxNVuMA0GCSqGSIb3DQEB
+CwUAMCcxJTAjBgNVBAMMHGlkcC1kZXYuZ3JhZHVhdGVpbnN0aXR1dGUuY2gwHhcN
+MTgwMzEzMTYyMjMzWhcNMjEwMzEzMTYyMjMzWjAnMSUwIwYDVQQDDBxpZHAtZGV2
+LmdyYWR1YXRlaW5zdGl0dXRlLmNoMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEAqXoKQDS+eCpGgNRrBEeqto7tHYNswCJkUtE7MMlVmhyJeaS7ziJQLm/q
+3ToGKvx3ljWpgT3+hqmYYzHQw17e1b9a5zsO95hGntvkEGsJfghGOhc+VRv8y7ME
+OdMgKhgCMKZ58xIuOGlOP1fbSJYKrlvYcdzSJJF98iHfzS6geklpkzqxLSEGl8jX
+trlaLnAr0nCkNYfqkgGaEq+8r7VM49ihb0/c9IIC/8Z6tQ8NCvG7OjUyPucKFzo1
+g2LOwDY1qjwVJzIFeiny5+pZsZmBICakvXQKt2Qog19WxbaeY9moug6ZeRBaVE2S
+xwqQVqeOuae8Y1IsisQA0shzBx9mFQIDAQABo38wfTAdBgNVHQ4EFgQUeLd8Dxow
+k2tlGeVz5paTfInqkvUwXAYDVR0RBFUwU4IcaWRwLWRldi5ncmFkdWF0ZWluc3Rp
+dHV0ZS5jaIYzaHR0cHM6Ly9pZHAtZGV2LmdyYWR1YXRlaW5zdGl0dXRlLmNoL2lk
+cC9zaGliYm9sZXRoMA0GCSqGSIb3DQEBCwUAA4IBAQCmkolHwzkTI8s6l7WTYpwE
+zOQ/8smWjN/ShepPtcpPIzAX3ZRKX4kdUP7yGkUEvxuvL/1O5d8qrF4ee7Jp0tng
+4o5+5tCygpk7bsvdhYEDddx/Ep1TJNIz2xfCipEWd+SB+aTu15rbzwBdvvF7/jKW
+3h12dpgtZqwJ8rtsscuEcqrAa599sGbjwhSIPO+Bydj3cCtPfy/c5GBVlFvV6uzW
+pa1lQomsWHiCP19hC2za2mWHu/WdtcLLphdA3t2K6+dmR9WX6O8YzcSyk6gLtZF9
+74o5L2zKETULoRmGqZ3OrRbkhHzEvPDP1vd4gYQL4ZLZtOXW/VbaS/6uWjoxBOdy
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-dev.graduateinstitute.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">graduateinstitute.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">Graduate Institute - Test IdP</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.graduateinstitute.ch/</OrganizationURL>
+		</Organization>                
+		<ContactPerson xmlns:remd="http://refeds.org/metadata" contactType="other" remd:contactType="http://refeds.org/metadata/contactType/security">
+			<GivenName>Wilfred</GivenName>
+			<SurName>Gander</SurName>
+			<EmailAddress>mailto:wilfred.gander@graduateinstitute.ch</EmailAddress>
+			
+		</ContactPerson>
+	</md:EntityDescriptor>
+
+	<!-- HCUGE Proxy (testing) -->
+	<md:EntityDescriptor entityID="https://hug-proxy.switch.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor errorURL="https://www.switch.ch/aai" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">hcuge.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">HCUGE Proxy (testing)</mdui:DisplayName>
+					<mdui:Description xml:lang="en">HCUGE Proxy (testing)</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIEODCCAqCgAwIBAgIVALulvw/+EaP3kRKrDNhH8l6ccJtMMA0GCSqGSIb3DQEB
+CwUAMB4xHDAaBgNVBAMME2h1Zy1wcm94eS5zd2l0Y2guY2gwHhcNMTkwNTIyMTMz
+OTMwWhcNMjIwNTIyMTMzOTMwWjAeMRwwGgYDVQQDDBNodWctcHJveHkuc3dpdGNo
+LmNoMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAh3Li4i4cp00pPoap
+zVE728D6OS1Zd2aZXl3jxwnIJUYY8zZw4q2XOFaPcXBngLNZvSFMx7haSOf1NBNm
+P2ryD2nSS0gozRKKrat1q76f9n7fLyFdc4kBUfCgGnSW5ARFWEeBro2XtfGu9WYM
+wRpoSpsybvLmOYPSDTaZ6PB8QVHnv+57co387Fobvi5VJyTbRZXvnhd/ne9zZxxx
+E4UA00aGKkK6QJVOm7WSmzZSwAUV+GWaif/+L4o975Ac1PBtBR59aojni39/8v85
+4ztdwbY3FXG9rIQHDmAHUK+R5ySvEjVz2Dx7Ec8sus6nwDhF7TaboNHnVn0yj5Au
+3U0oYqYuMYJjV/WFIayRGdeBemsVCcXOSO41suCzeNJZANTsCzbRzzyTmY3I/e8R
+Iz/Y3AtPWEl79E2FJlgFOTCshAo11x1929EY4Fqxhw1qH+UWA49EydJMefwAvjwI
+0pcV4jlWmrdPFIjcumFqVz/KmgcT15H+wK78nl83d82pkOkNAgMBAAGjbTBrMB0G
+A1UdDgQWBBR2O42VbIIgaKq5ksqBMo+TRkvOwDBKBgNVHREEQzBBghNodWctcHJv
+eHkuc3dpdGNoLmNohipodHRwczovL2h1Zy1wcm94eS5zd2l0Y2guY2gvaWRwL3No
+aWJib2xldGgwDQYJKoZIhvcNAQELBQADggGBAHrL4lzXBGSf2yBnYttMU0pT/B9Q
+xFDmvjS530aV4YScqHpymOFRLyiNb6jdqc8fC642y6M011CvgWmfSfSi7ERXu0fy
+FdR5LWL2ip+6d0KKmULJyODs+udIUisReLMWtNl6fjWki0XioU7hP911Az7wXop2
+D4qJ3evQF8COTKH5G7bTPAx9Z0Gc1mqbLTGBl4V2HrlAeeqqoXU5ImwJUUdLOXuX
++7L/O3GKalXU1kEQduqko0soGhI0w0IXn0DoydXcmLuyBKF6GRrzfjXK3seqvsWH
+T3vul4hEXQ6Gm4yT6jt9ErVk/h4Be8k7OWKxkCbiCBnfAY3+VLx+HXgonAqllTMn
+etyHDcJVfn86eLoblk7VZB9BZZZCu1Kz72v0D9crbBtXCd5KCm9DWEOdF1XW8ZZ1
+Nvs/TDeLsZt74q+K1LJZvqO3gb0BAyCro0Xlkv6NrHmFu/SbVs3DSwHpxhwQIXKU
+kGvnsME0QPNqtMrddUyoYZY0rDZxsMIZysGZMA==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://hug-proxy.switch.ch/idp/profile/SAML2/POST/SSO"/>
+		</md:IDPSSODescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">hcuge.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">HCUGE Proxy (testing)</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.hcuge.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- HEP Vaud - TEST - Haute école pédagogique du canton de Vaud -->
+	<md:EntityDescriptor entityID="https://aai-login-int.hepl.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">hepl.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">HEP Vaud - TEST - Haute école pédagogique du canton de Vaud</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="fr">HEP Vaud - TEST - Haute école pédagogique du canton de Vaud</mdui:DisplayName>
+					<mdui:Description xml:lang="en">Haute école pédagogique du canton de Vaud</mdui:Description>
+					<mdui:Description xml:lang="fr">Haute école pédagogique du canton de Vaud</mdui:Description>
+					<mdui:Logo height="16" width="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAA+0lEQVR4nGJgWPz4PyEsu/bZ/7oLH/8Xnfnw32zbS1R5Ygxou/zpPwj8+PPvfw3QIJIM4Fz25P/n3//ABmx58v2/1qYXpBmQevzdfxiw2vESUw0hAy6//wXWfPPjb+xq8Gm22fkKbjvIJSQbsObhN7DmT7/+/ecAhgVJBkiseQa3fcqNz7i9iUuiFRp1IKC0/jlpBjAC8cvvf8Gatz/9jj+dYBMMPfQGbrv73tekG3Dm7U+w5rufcUQdPgN0Nr+A2w5K+yQZILLq6f+Fd7/C073AyqekGZBz6v3/r9B0Pxlf1OEywGjri//l5z6Ao1ARX9QhYQAAAAD//wMADdzAkcAvUzkAAAAASUVORK5CYII=</mdui:Logo>
+					<mdui:Logo height="60" width="80">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAA8CAIAAAB+RarbAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA/dpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMDY3IDc5LjE1Nzc0NywgMjAxNS8wMy8zMC0yMzo0MDo0MiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIgeG1wTU06T3JpZ2luYWxEb2N1bWVudElEPSJ1dWlkOjVEMjA4OTI0OTNCRkRCMTE5MTRBODU5MEQzMTUwOEM4IiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOjE0NUJCNkZBNUQ4NDExRTZCRjk1QkJEMzMxRjNEMEE5IiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjE0NUJCNkY5NUQ4NDExRTZCRjk1QkJEMzMxRjNEMEE5IiB4bXA6Q3JlYXRvclRvb2w9IkFkb2JlIElsbHVzdHJhdG9yIENTNSI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOkZFN0YxMTc0MDcyMDY4MTE4QTZEOTFCNTYxODE5QTkwIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOkZFN0YxMTc0MDcyMDY4MTE4QTZEOTFCNTYxODE5QTkwIi8+IDxkYzp0aXRsZT4gPHJkZjpBbHQ+IDxyZGY6bGkgeG1sOmxhbmc9IngtZGVmYXVsdCI+TE9HT1MgSEVQIFZBVUQgLSBERUNMSU5BSVNPTlM8L3JkZjpsaT4gPC9yZGY6QWx0PiA8L2RjOnRpdGxlPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PlHNYA4AAAjSSURBVHja7JhpbBTXHcBn3hw7uzuz6z28u7bX5jA2GINtahKqNgSaYiJKwAmBluKWkoiSklRK1UZplajqFVWN0lSqmn6oxFWUKGqgalKkBCQnGEMxNgQDjoFgsLHN+ljvfczO+V7fsAaDY2hF/AnmaeQdv337n/f7329IhBDxIA3SBDaBTWAT2AQ2gU1gE9gENoFNYBPYBDaBTeAHCViBKKchiiRsNAlI8v4HfulYvOV0ArDg90/4VgSt9yswffMuK+paWgcMFOX72ckngEkWUFZA0gBQ5H0MDIgHbIAp4/qBcOlxBbBgNKvvOJ/ZfyFDEmi+z/J8jaPceduyqKR/2C9djCtYW/Nc7KoZnJujvij6Ylw9NJAbzkKBJR4psiwruVsi3PZJ9PKYDEjirYbCeS5mKKvjShGwTb8DTmTp51ti7Z1J1sNAGalxBU8DBiANAgt4tTHw1Mzx7TaHpFcOjGppDcrQUBBHMU5m+6PuLXPtt8p96Xis5WQSr0EQGVWOJgOzbDsf9wZs9Bc3sf+y+Np7Q0iF7lKu+dkyrLw93ekPLmX/8aQ/lNavprXKAsZCkWciypFrua3VwrmoijXosoBpsDAeeJeUleK8rJxQCQSQTrz+UXjJlpJiq7H4P32iFJJYDyuUcvirbFjRMtqf3x+RnvD/qJofV0q/+HFrDFgo7C+0QGkZnaTAcI+4MTX8r6YSFz15o2+fTdI2CkHw40c8eVfhAEim1D+eSMQI1DssV9rpMhcTSmkeG/jb2eShjsS2Bt9zC4VpiGE9CzkH+NPTgaPfLd67sZh30dg4ckrbfz6bX9CT1pkC5peNgSMbS1qbSl5c5aN5QFnAriPRa1k9v6Y9rEAJ2t30r9cFDn4v+If1RUIBRdmp5LD82yOxSU/892VxcCBHkKQ/yD1dOe4mdiu1od4VdDM2QM72cTNKuGNRpbyEWzaH9wtM+Vx+YSE7HTGMkC7pTUu9S4s5wohPZvMi51sHxwBN9qW1/JKBqPzko+7GWeMevnmePSpp77TG1LSGw/4ni514srVPpAX6L6v9tV5jWytKuFlr/E37hpBOt/eJ8Zzusk7E/DvdKSOyNPjt6gmLrZnJ4UjD5VGDxiculJvn8naGzGmw2i28UCNQ99oLTnZpLLuEn5j04myEMwlEMjIekFEg1FHr1dzaIUnVjfDnGAARou0U0ojPYgpeM5LRI4NSZbWQp82PciezpFI4djKhSsTncfWrN4Cb+3NX+nI4yN0Bdkv1bS7aPJjzWSksZCgLi+0AP+1iXDs+Ij9TxasQ0eQ0ZWmDecqydP0BozmoaWisJwsljcyHIs5JLIUjUI3LqbgFT5wYldWkGuAnS/bjKEUEgoSkTcjf1ZUykqYON9xO2zokvXY0+o1yvm1U9lgoTHsqrLgZUgDEr9rjp4fkN5Z7qlzM9AAT6I7aG0irakprXOHFXhDKqAiRPAtmOgx1x2Xou263lgEJW2wgoUz67bmwjN0HXzdr2LGQdKlXxDOCl9my4Dbg3riaS+nXMrqiIncRdWFMHktpqoVi7NTVmBpLqFEJTpuF7zJwUdUzepGN2jafvzn5Yb84IsK0DBtKjci/MGbk8P5ecXd3+pkbdvtnT/YKZgOk4KAW+sZdfcfZFNIQgnDDAhcDbtMydu8SB/0VHxsR0cWE+ouHCj7oy9V52SBPhbJ6KKPhsjRtwGiq+/x2BiIyvtvZEu0aU5qqeHyi3NmV7j6XwpUJF+3nXpkzJsJ4RMUJGSrorx9HTkXU5UHuxIjceiaFK5OWUTbUuvOiOkbkbqwCGtgLqB8smKLANJQaedFjIdwcXkVurLBjP3dZqLkFDL6mdsCMjp2s0Er9X8Awq8lhGVdOpE4g43slIkOcq7JGlq6fZdv/aVIX9bZTiRNnUoY+kNFX4Jz883VFPCDf7klrom7hKRKbTkVt7fG2dlz7SCwWB3b9wwXbaxx5yX/vShttCSLWVhXYmcnV8bOYuqs7vb7CbqfJ108mX17svJDUmj/PbF4ovBtXG8qsXRFF1FC1m2m5Jq0rt3VF1aQC8QzPkPgvVtBiHyvpSNbQp2F5gZd9vNQ6GXhdjeDxMFaarAlMZNfaAPudtX4sYnmJ4a4NxdyMzcGXj8aGrklGpwUI3F24fZbffd31kN/wsfD10MJu3/iwEz/v0OkUNjUJCJqnvr/c/eIN2rNjSkdPhmSAVaC21kxh3o7B3KUhqZUhTw/mQmntN4fVcg87x8vsuyx2nE8f97KLKu04le3oyagE+dOe7JLZNhIiRYIdMQWxwMECKaWmJdgZyvVF1Nq5/BTAK0utK0snt7szBPrVxQW3zuAu7/01ftzuXYiruNmuLGBnO245YwKc5AkdJzAb/cP5/Nb5jksJBRuwzsPYbjHju+czumioZlWVs8AyhQfi7Ia/fmyOfXGQOzyYWzfH3j6iYAHFDtJXaK3iyZZ+MZXV1y9w9Ka1+S7m4IA0OCY/VSUsrbC3DIikQpT5uU8Gc9uXeVpC0pKA5R6T1s0xU6DxdZcFEOX1Rc0QJiuxN6kdvpgBLMni5FfjnPLndeVC3Syh9rrt869f6gvHN61nEhRnG0ixNi/RONuWn7ycUMt4W9M8o1H7mt9yJCR/s9SS744eu/3tzT0Cf5mxpwt7m5ERVtbzhXc4DwUivTjye6MgEh5xOhzB0rJUMiE4nCfa2vbs3v3Gm2/+rLbo1vUv3AgWPGw0iQ9w01OW/ufAfRj2Z+zYSJ/6UN2f1j7qTGEHYBzMs7XOO8lpPnr8vX376urqOjo6JEnatGmTrusHDhyoqKgQnE4A7v3YOM0HToYxDhI4k9F36P0OXBGhBikbtXKRUMbfsX58a/VqRVGKioowZzAYDIfDe/fuxf+6XC6LxfJlgKf5vXRGheEcxHmryAo4eoptxWRdMw6LhMDglvRuDfHo6GhhYeHw8DDHcSRJ9vX11dfXd3Z28jyP7Wy+iDeBTWAT2AQ2gU1gE9gENoFNYBPYBDaBTWAT2AS+Of4rwAAxh0sAIU/DbwAAAABJRU5ErkJggg==</mdui:Logo>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>hepl.ch</mdui:DomainHint>
+					<mdui:GeolocationHint>geo:46.5128606,6.621523</mdui:GeolocationHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDPzCCAiegAwIBAgIUTNouO1eUODt3UOaXIpR9BDMNoKUwDQYJKoZIhvcNAQEL
+BQAwIDEeMBwGA1UEAwwVYWFpLWxvZ2luLWludC5oZXBsLmNoMB4XDTE4MDgwNzA5
+NTkyNloXDTIxMDgwNzA5NTkyNlowIDEeMBwGA1UEAwwVYWFpLWxvZ2luLWludC5o
+ZXBsLmNoMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqpQ11o5ERmiO
+u/iFLxgFihf3WWIh3MA373D/i16DO1/W6ZpT3wS9rJ502/44s/DPFdOErOBO8h6B
+/kZim2iaEiaX3ahvKo33+B39fbPz7PFzzuYAdz0h0uP6bMZd4P3FguBMdm+0Bg9/
+EXaNyx71LFE4aw5o9N4GXhxsAoakD7kGPsbC98SmPPwlhwhxJx0W0OqcyTJsNtcq
+zJe5wr+g4pllwvaJRq9SyMC7Wt0Ndby5fmPb3jKzh2VqO2z/Fq9Clf/ZVjXS2ZO0
+jaHWpkxyTm5po1ilb6iUKaEkY8Gvft/uZwJGjmKQjAmBTuSN+vSaWQr6rWs6BhZv
+TsBsmHGh3QIDAQABo3EwbzAdBgNVHQ4EFgQUtZrMPv9zWTX5CnbL4SFBmWo9Eb0w
+TgYDVR0RBEcwRYIVYWFpLWxvZ2luLWludC5oZXBsLmNohixodHRwczovL2FhaS1s
+b2dpbi1pbnQuaGVwbC5jaC9pZHAvc2hpYmJvbGV0aDANBgkqhkiG9w0BAQsFAAOC
+AQEAerJhdO/UJSb0uvT67kOLWi8SVoFO1M4qnT7xq42CV+K42vuoK5yfHhcYqrpP
+I1/dI/N98ayAF7hAKUQdVtuIXrwBOeKR+MFfOOgMSRvGoZHhYApaklOS4ZtsNeOf
+Tp+jt90GDC5Evl4GT5TOEzGeHO76BCLiRPxj2d5H6ILlVePabRzSarxSG0CLv9DE
+rD7xz/xKvX2Olj+02enMHXtAJYOLeNHbeTW6m4AvI91czWAISQbEkjtDWFo7Dugx
+q86sgQ1la6oiGuWbDpjrCofMaqgU0fGSZ5A7uz1WHwv5XmxGiqUFrGRGJWiuKL8z
+2Z9142lGkwsyF7KcNmhIz0HvkQ==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIHDTCCBfWgAwIBAgIUOxZRvReUMcNZz4X/srT5oXI1YJMwDQYJKoZIhvcNAQEL
+BQAwTTELMAkGA1UEBhMCQk0xGTAXBgNVBAoTEFF1b1ZhZGlzIExpbWl0ZWQxIzAh
+BgNVBAMTGlF1b1ZhZGlzIEdsb2JhbCBTU0wgSUNBIEcyMB4XDTE4MDcyMzA2MzYw
+NVoXDTIwMDcyMzA2NDUwMFowgZAxCzAJBgNVBAYTAkNIMQ0wCwYDVQQIDARWYXVk
+MREwDwYDVQQHDAhMYXVzYW5uZTEyMDAGA1UECgwpSGF1dGUgZWNvbGUgcGVkYWdv
+Z2lxdWUgZHUgY2FudG9uIGRlIFZhdWQxCzAJBgNVBAsMAlVJMR4wHAYDVQQDDBVh
+YWktbG9naW4taW50LmhlcGwuY2gwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDkEaCvQRG1InFbRNwvWLw/zC8QWvQP6JkjYcrcIzqjBmuBRT+7g9mFWnUz
+rZpRHtc2uKfKzqoAzkmTxY8CMAK3tTWZ/C2+HcHLh+BHfNn5VqmKf3SZunGOEEMl
+WjJnIakZ0DQ6C2kKGWnH6bimwfqRlzEPXBSjDcfJmDlK141GVjKm3eQNyqa9tJ+K
+rpH+krqpzMOT78MUeRxCTLgOV44FdxiyYlWWLACdwAzdhzL2BcQ3puHP2cdS2NvO
+5hHTvwuWkM83qUBsNRIOYszZjxrhD5/+S13UYDIMGuzC/DJDJmqKrvmcZq/MA/aK
+J7ynhn4Zv2ltXqNdTBJ0ZA5R77HxAgMBAAGjggOfMIIDmzAJBgNVHRMEAjAAMB8G
+A1UdIwQYMBaAFJEZYq1bF6cw+/DeOSWxvYy5uFEnMHMGCCsGAQUFBwEBBGcwZTA3
+BggrBgEFBQcwAoYraHR0cDovL3RydXN0LnF1b3ZhZGlzZ2xvYmFsLmNvbS9xdnNz
+bGcyLmNydDAqBggrBgEFBQcwAYYeaHR0cDovL29jc3AucXVvdmFkaXNnbG9iYWwu
+Y29tMCAGA1UdEQQZMBeCFWFhaS1sb2dpbi1pbnQuaGVwbC5jaDBRBgNVHSAESjBI
+MEYGDCsGAQQBvlgAAmQBATA2MDQGCCsGAQUFBwIBFihodHRwOi8vd3d3LnF1b3Zh
+ZGlzZ2xvYmFsLmNvbS9yZXBvc2l0b3J5MB0GA1UdJQQWMBQGCCsGAQUFBwMCBggr
+BgEFBQcDATA6BgNVHR8EMzAxMC+gLaArhilodHRwOi8vY3JsLnF1b3ZhZGlzZ2xv
+YmFsLmNvbS9xdnNzbGcyLmNybDAdBgNVHQ4EFgQU1Pn/sheXLouvqFfaFgyd7vbM
+bYcwDgYDVR0PAQH/BAQDAgWgMIIB9wYKKwYBBAHWeQIEAgSCAecEggHjAeEAdwCk
+uQmQtBhYFIe7E6LMZ3AKPDWYBPkb37jjd80OyA3cEAAAAWTF4n8QAAAEAwBIMEYC
+IQCV1PFFXoEehdjnFfG+TZfDqHOSAXxDGrvehqwS2xU6vAIhAPJLjHv/K0JYdHXT
+CKCsd/ydirxGdszqz1umlorM/QwrAHYAu9nfvB+KcbWTlCOXqpJ7RzhXlQqrUuga
+kJZkNo4e0YUAAAFkxeJ+5wAABAMARzBFAiEAnFk2o81APutnK7aGOCxNHhFajdVm
+uZ3rQP5mJdevnXwCIFBeHHfBkR/A6vcki/JJqXoT9mw4rKJYPaE2iN6RI2q7AHcA
+VhQGmi/XwuzT9eG9RLI+x0Z2ubyZEVzA75SYVdaJ0N0AAAFkxeKAvgAABAMASDBG
+AiEAy91p1RBwrM8LeifXSF14+8H1n/cTOYpO/9BtiFA+Y3QCIQDYmUAG8b1Emh1v
+xEXiG99lkJQVuAzQP7x9F09Drn4ttgB1AG9Tdqwx8DEZ2JkApFEV/3cVHBHZAsEA
+KQaNsgiaN9kTAAABZMXigXMAAAQDAEYwRAIgbTw3md0jQB4OsNPBIhATQE7g8x5o
+5jyb0ePpbixCh5gCIEwFZL4LFGXgE2qY4MvHIyv8PGMHPaCFw8pH3srrczn7MA0G
+CSqGSIb3DQEBCwUAA4IBAQDfyGJCOa8tIzW042ycjpBs/DDCpiLNMTIjvwO3kuMA
++aIZ/CjXeII9xbFdVcEpLhgEfTC7i169PFGvg/tKI91BdOI3vSlcpb7ueVseA95e
+8JA3Opg/8nCZHQcNSSb357tKPKHH7en0jqzx/2VOqjNFVly22FVjWo8KI+2+43Mr
++lLKAne/+/TD32ku3x1qW/QzXivK5kM2knZnHY/MiprOBSR6FehKRgDqYlDMyvhI
+FGy+aDkkq5ZV7C8Tror84z05WWFvDHiO3P9rVRXqRJvnVC8FLFhn2byCcHLF5ebp
+nT2DecWFfixBKpGwMp0OfspUijtXEFbEHmVjYXavlIIm
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDQDCCAiigAwIBAgIVAPuka2YYfe3PwVaJUcFKGoRWDRAtMA0GCSqGSIb3DQEB
+CwUAMCAxHjAcBgNVBAMMFWFhaS1sb2dpbi1pbnQuaGVwbC5jaDAeFw0xNjA3MjUx
+MzQ3NDdaFw0xOTA3MjUxMzQ3NDdaMCAxHjAcBgNVBAMMFWFhaS1sb2dpbi1pbnQu
+aGVwbC5jaDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKGhLVo2UrTo
+WC8JschXReK26ymeR+96nkq8vh5UBiD6j3xYHE9oevtXYuoArMcD/BJR1Bwzz5wW
+kONtFg0X6XpVctvydV3x8ryEi9qXgMjx2sUoWEItk0cR0gjeCOpaNuh1JpkmpfqI
+fzQAwBgVq26kVsj3fUOcJ0KvVnaYYGoZf4po2JEKKtUJPDgKm3Ietoqvg1GriJwd
+k1PF4YDpzz2B1XGKbDwGSYgmxrUyzOoWi/N92XinTYFfMd7YJd1GnBdxdfdN+odM
+qiPDpRNCKoza0lE+ptcnJXMuXzFLbd85bzc5UxxQWHyOT4iX8JX0qbJl8OCmIfvv
+VJmPmpy75BcCAwEAAaNxMG8wHQYDVR0OBBYEFL0IxgtlB+YInRE+NLSsXVc7qvN9
+ME4GA1UdEQRHMEWCFWFhaS1sb2dpbi1pbnQuaGVwbC5jaIYsaHR0cHM6Ly9hYWkt
+bG9naW4taW50LmhlcGwuY2gvaWRwL3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQAD
+ggEBACrwHIxiM3+1AkGBzpGn0UbSGQUKPc8+1+RRoLcIZGqAptTOg7lzAVJ9j/5w
+5HJlBKVbEJ0Em+L/LQS3eMJM94lwNjc3zlFQh/0xo/0AHliiWCBn00xesvFbu1Wx
+G2BTzlA1ZLaWpeP2K0caUMvABFVVZm6oq3UPlIHNX3YEA5/r5tJb4qP0P0NWA+oo
+iiJ98FSw+2jEvoCV6vTmmYUMdrsASI5Jl484maWI+G3J4rjmyaR+IYOoKV7mYKHG
+KT5yUdzA1vOF4kEfG5DlPrwLnIkivtkXFk5yAFgfWZvl2LmhaSKGbu24BvJ4915Z
+LS8+eshenGJr2pxeZJcAM9xqyU8=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-login-int.hepl.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-login-int.hepl.ch/idp/profile/SAML2/POST/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">hepl.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDPzCCAiegAwIBAgIUTNouO1eUODt3UOaXIpR9BDMNoKUwDQYJKoZIhvcNAQEL
+BQAwIDEeMBwGA1UEAwwVYWFpLWxvZ2luLWludC5oZXBsLmNoMB4XDTE4MDgwNzA5
+NTkyNloXDTIxMDgwNzA5NTkyNlowIDEeMBwGA1UEAwwVYWFpLWxvZ2luLWludC5o
+ZXBsLmNoMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqpQ11o5ERmiO
+u/iFLxgFihf3WWIh3MA373D/i16DO1/W6ZpT3wS9rJ502/44s/DPFdOErOBO8h6B
+/kZim2iaEiaX3ahvKo33+B39fbPz7PFzzuYAdz0h0uP6bMZd4P3FguBMdm+0Bg9/
+EXaNyx71LFE4aw5o9N4GXhxsAoakD7kGPsbC98SmPPwlhwhxJx0W0OqcyTJsNtcq
+zJe5wr+g4pllwvaJRq9SyMC7Wt0Ndby5fmPb3jKzh2VqO2z/Fq9Clf/ZVjXS2ZO0
+jaHWpkxyTm5po1ilb6iUKaEkY8Gvft/uZwJGjmKQjAmBTuSN+vSaWQr6rWs6BhZv
+TsBsmHGh3QIDAQABo3EwbzAdBgNVHQ4EFgQUtZrMPv9zWTX5CnbL4SFBmWo9Eb0w
+TgYDVR0RBEcwRYIVYWFpLWxvZ2luLWludC5oZXBsLmNohixodHRwczovL2FhaS1s
+b2dpbi1pbnQuaGVwbC5jaC9pZHAvc2hpYmJvbGV0aDANBgkqhkiG9w0BAQsFAAOC
+AQEAerJhdO/UJSb0uvT67kOLWi8SVoFO1M4qnT7xq42CV+K42vuoK5yfHhcYqrpP
+I1/dI/N98ayAF7hAKUQdVtuIXrwBOeKR+MFfOOgMSRvGoZHhYApaklOS4ZtsNeOf
+Tp+jt90GDC5Evl4GT5TOEzGeHO76BCLiRPxj2d5H6ILlVePabRzSarxSG0CLv9DE
+rD7xz/xKvX2Olj+02enMHXtAJYOLeNHbeTW6m4AvI91czWAISQbEkjtDWFo7Dugx
+q86sgQ1la6oiGuWbDpjrCofMaqgU0fGSZ5A7uz1WHwv5XmxGiqUFrGRGJWiuKL8z
+2Z9142lGkwsyF7KcNmhIz0HvkQ==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIHDTCCBfWgAwIBAgIUOxZRvReUMcNZz4X/srT5oXI1YJMwDQYJKoZIhvcNAQEL
+BQAwTTELMAkGA1UEBhMCQk0xGTAXBgNVBAoTEFF1b1ZhZGlzIExpbWl0ZWQxIzAh
+BgNVBAMTGlF1b1ZhZGlzIEdsb2JhbCBTU0wgSUNBIEcyMB4XDTE4MDcyMzA2MzYw
+NVoXDTIwMDcyMzA2NDUwMFowgZAxCzAJBgNVBAYTAkNIMQ0wCwYDVQQIDARWYXVk
+MREwDwYDVQQHDAhMYXVzYW5uZTEyMDAGA1UECgwpSGF1dGUgZWNvbGUgcGVkYWdv
+Z2lxdWUgZHUgY2FudG9uIGRlIFZhdWQxCzAJBgNVBAsMAlVJMR4wHAYDVQQDDBVh
+YWktbG9naW4taW50LmhlcGwuY2gwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDkEaCvQRG1InFbRNwvWLw/zC8QWvQP6JkjYcrcIzqjBmuBRT+7g9mFWnUz
+rZpRHtc2uKfKzqoAzkmTxY8CMAK3tTWZ/C2+HcHLh+BHfNn5VqmKf3SZunGOEEMl
+WjJnIakZ0DQ6C2kKGWnH6bimwfqRlzEPXBSjDcfJmDlK141GVjKm3eQNyqa9tJ+K
+rpH+krqpzMOT78MUeRxCTLgOV44FdxiyYlWWLACdwAzdhzL2BcQ3puHP2cdS2NvO
+5hHTvwuWkM83qUBsNRIOYszZjxrhD5/+S13UYDIMGuzC/DJDJmqKrvmcZq/MA/aK
+J7ynhn4Zv2ltXqNdTBJ0ZA5R77HxAgMBAAGjggOfMIIDmzAJBgNVHRMEAjAAMB8G
+A1UdIwQYMBaAFJEZYq1bF6cw+/DeOSWxvYy5uFEnMHMGCCsGAQUFBwEBBGcwZTA3
+BggrBgEFBQcwAoYraHR0cDovL3RydXN0LnF1b3ZhZGlzZ2xvYmFsLmNvbS9xdnNz
+bGcyLmNydDAqBggrBgEFBQcwAYYeaHR0cDovL29jc3AucXVvdmFkaXNnbG9iYWwu
+Y29tMCAGA1UdEQQZMBeCFWFhaS1sb2dpbi1pbnQuaGVwbC5jaDBRBgNVHSAESjBI
+MEYGDCsGAQQBvlgAAmQBATA2MDQGCCsGAQUFBwIBFihodHRwOi8vd3d3LnF1b3Zh
+ZGlzZ2xvYmFsLmNvbS9yZXBvc2l0b3J5MB0GA1UdJQQWMBQGCCsGAQUFBwMCBggr
+BgEFBQcDATA6BgNVHR8EMzAxMC+gLaArhilodHRwOi8vY3JsLnF1b3ZhZGlzZ2xv
+YmFsLmNvbS9xdnNzbGcyLmNybDAdBgNVHQ4EFgQU1Pn/sheXLouvqFfaFgyd7vbM
+bYcwDgYDVR0PAQH/BAQDAgWgMIIB9wYKKwYBBAHWeQIEAgSCAecEggHjAeEAdwCk
+uQmQtBhYFIe7E6LMZ3AKPDWYBPkb37jjd80OyA3cEAAAAWTF4n8QAAAEAwBIMEYC
+IQCV1PFFXoEehdjnFfG+TZfDqHOSAXxDGrvehqwS2xU6vAIhAPJLjHv/K0JYdHXT
+CKCsd/ydirxGdszqz1umlorM/QwrAHYAu9nfvB+KcbWTlCOXqpJ7RzhXlQqrUuga
+kJZkNo4e0YUAAAFkxeJ+5wAABAMARzBFAiEAnFk2o81APutnK7aGOCxNHhFajdVm
+uZ3rQP5mJdevnXwCIFBeHHfBkR/A6vcki/JJqXoT9mw4rKJYPaE2iN6RI2q7AHcA
+VhQGmi/XwuzT9eG9RLI+x0Z2ubyZEVzA75SYVdaJ0N0AAAFkxeKAvgAABAMASDBG
+AiEAy91p1RBwrM8LeifXSF14+8H1n/cTOYpO/9BtiFA+Y3QCIQDYmUAG8b1Emh1v
+xEXiG99lkJQVuAzQP7x9F09Drn4ttgB1AG9Tdqwx8DEZ2JkApFEV/3cVHBHZAsEA
+KQaNsgiaN9kTAAABZMXigXMAAAQDAEYwRAIgbTw3md0jQB4OsNPBIhATQE7g8x5o
+5jyb0ePpbixCh5gCIEwFZL4LFGXgE2qY4MvHIyv8PGMHPaCFw8pH3srrczn7MA0G
+CSqGSIb3DQEBCwUAA4IBAQDfyGJCOa8tIzW042ycjpBs/DDCpiLNMTIjvwO3kuMA
++aIZ/CjXeII9xbFdVcEpLhgEfTC7i169PFGvg/tKI91BdOI3vSlcpb7ueVseA95e
+8JA3Opg/8nCZHQcNSSb357tKPKHH7en0jqzx/2VOqjNFVly22FVjWo8KI+2+43Mr
++lLKAne/+/TD32ku3x1qW/QzXivK5kM2knZnHY/MiprOBSR6FehKRgDqYlDMyvhI
+FGy+aDkkq5ZV7C8Tror84z05WWFvDHiO3P9rVRXqRJvnVC8FLFhn2byCcHLF5ebp
+nT2DecWFfixBKpGwMp0OfspUijtXEFbEHmVjYXavlIIm
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDQDCCAiigAwIBAgIVAPuka2YYfe3PwVaJUcFKGoRWDRAtMA0GCSqGSIb3DQEB
+CwUAMCAxHjAcBgNVBAMMFWFhaS1sb2dpbi1pbnQuaGVwbC5jaDAeFw0xNjA3MjUx
+MzQ3NDdaFw0xOTA3MjUxMzQ3NDdaMCAxHjAcBgNVBAMMFWFhaS1sb2dpbi1pbnQu
+aGVwbC5jaDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKGhLVo2UrTo
+WC8JschXReK26ymeR+96nkq8vh5UBiD6j3xYHE9oevtXYuoArMcD/BJR1Bwzz5wW
+kONtFg0X6XpVctvydV3x8ryEi9qXgMjx2sUoWEItk0cR0gjeCOpaNuh1JpkmpfqI
+fzQAwBgVq26kVsj3fUOcJ0KvVnaYYGoZf4po2JEKKtUJPDgKm3Ietoqvg1GriJwd
+k1PF4YDpzz2B1XGKbDwGSYgmxrUyzOoWi/N92XinTYFfMd7YJd1GnBdxdfdN+odM
+qiPDpRNCKoza0lE+ptcnJXMuXzFLbd85bzc5UxxQWHyOT4iX8JX0qbJl8OCmIfvv
+VJmPmpy75BcCAwEAAaNxMG8wHQYDVR0OBBYEFL0IxgtlB+YInRE+NLSsXVc7qvN9
+ME4GA1UdEQRHMEWCFWFhaS1sb2dpbi1pbnQuaGVwbC5jaIYsaHR0cHM6Ly9hYWkt
+bG9naW4taW50LmhlcGwuY2gvaWRwL3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQAD
+ggEBACrwHIxiM3+1AkGBzpGn0UbSGQUKPc8+1+RRoLcIZGqAptTOg7lzAVJ9j/5w
+5HJlBKVbEJ0Em+L/LQS3eMJM94lwNjc3zlFQh/0xo/0AHliiWCBn00xesvFbu1Wx
+G2BTzlA1ZLaWpeP2K0caUMvABFVVZm6oq3UPlIHNX3YEA5/r5tJb4qP0P0NWA+oo
+iiJ98FSw+2jEvoCV6vTmmYUMdrsASI5Jl484maWI+G3J4rjmyaR+IYOoKV7mYKHG
+KT5yUdzA1vOF4kEfG5DlPrwLnIkivtkXFk5yAFgfWZvl2LmhaSKGbu24BvJ4915Z
+LS8+eshenGJr2pxeZJcAM9xqyU8=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-login-int.hepl.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">hepl.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">HEP Vaud - TEST - Haute école pédagogique du canton de Vaud</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="fr">HEP Vaud - TEST - Haute école pédagogique du canton de Vaud</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.hepl.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="fr">http://www.hepl.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- HFTM Test Identity Provider -->
+	<md:EntityDescriptor entityID="https://aai.hftm.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">hftm.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">HFTM Test Identity Provider</mdui:DisplayName>
+					<mdui:Description xml:lang="en">Bootstrapped IdP of: hftm.ch</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDFzCCAf+gAwIBAgIUHJJF4w8cHL4ahB/wb3IPTRmNg/wwDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAwwLYWFpLmhmdG0uY2gwHhcNMTYxMTE3MDk1NDI3WhcNMTkx
+MTE3MDk1NDI3WjAWMRQwEgYDVQQDDAthYWkuaGZ0bS5jaDCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAJ9gkxa3PEZgtIJBTMBWxSaqxOuwDXYSdON13g9O
+fTVeK6bOC2yuA5P6HP5IfDCPbJINvfMZ5DWEAu7ahihKuqeiITE2QTn2/uxnXngj
+Fq5pHLWnJ1JEkkmzkVsd5DYIj5WOn/GakFMws3fviESSobHpxzifodvWOTpa+pvR
+iDdBbouYKQlWo++WyJxB5wFFTe3wbOCXm8VemTs/eQaBm3xijlbJ8JuQWAV2Ql5b
+Rumt3K4s32nSLVD38VOqL7cw4eVka8JAlL3lMJHDhtXawQD0IzyPGXChL3XvHvsJ
+At8A3XuK+VJbd2OlXNZZUE5f7/+bqA5BgkHQ+qxdnBQiUycCAwEAAaNdMFswHQYD
+VR0OBBYEFMUw0gLcZBqgW05/g/a0RmB1EtdoMDoGA1UdEQQzMDGCC2FhaS5oZnRt
+LmNohiJodHRwczovL2FhaS5oZnRtLmNoL2lkcC9zaGliYm9sZXRoMA0GCSqGSIb3
+DQEBCwUAA4IBAQCUjED0xpRTUSwBehZkg221ZRkvpprnNZ20+jPxYXBCyhutMXn4
+srdksYim3zjHijdjnR0WcfAmW3CuKAL+Zp3vgL9d8X1aEbMVaxOLx3wWUEe8lEgD
+0WAQ6bQkyTtV46c6cs+AUvw7iIoybgN3bo+DGJBtRqdHkvDJgnxr6mMkCl3z7BEG
+hpOVUS2GC7nZioPLUG4DgKHuFUfab1PA2BGdgkq3l/7qzTfwoK/k/uhPLhCAkKN5
+Jddm3IS9iEJG81r/gF1PqHlDyasCq1qe6W1wicVm7p8qKl6wbivFNtXR1bhZHh3G
+g8NmxpkGQDpxXle7HwRW7Lw9WWWOQvuVOYLE
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai.hftm.ch/idp/profile/SAML2/POST/SSO"/>
+		</md:IDPSSODescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">hftm.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">HFTM Test Identity Provider</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.hftm.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- HSLU - Hochschule Luzern (Test IdP) -->
+	<md:EntityDescriptor entityID="https://idp.hslu-lab.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor errorURL="http://hotline.hslu.ch/" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">hslu.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="de">HSLU - Hochschule Luzern (Test IdP)</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="en">HSLU - Lucerne University of Applied Sciences and Arts (Test IdP)</mdui:DisplayName>
+					<mdui:Description xml:lang="de">Hochschule Luzern (Test IdP)</mdui:Description>
+					<mdui:Description xml:lang="en">Lucerne University of Applied Sciences and Arts (Test IdP)</mdui:Description>
+					<mdui:Logo height="16" width="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyZpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMDY3IDc5LjE1Nzc0NywgMjAxNS8wMy8zMC0yMzo0MDo0MiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6OTczNUREQTEzMTI3MTFFNTk2NUJBMkVFMjZDMkMzOTciIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6OTczNUREQTAzMTI3MTFFNTk2NUJBMkVFMjZDMkMzOTciIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTUgKFdpbmRvd3MpIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6Mzk4MjExRDYzMTI1MTFFNUI5MzFGRTRCMzQ1NjFBRjkiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6Mzk4MjExRDczMTI1MTFFNUI5MzFGRTRCMzQ1NjFBRjkiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz5+dKV2AAAA9UlEQVR42mL8//8/AymAiYFEwPL+/XsIi/X8ebbdu7Eq+lpWhtCQnp4OYTm8fWv57BlWDe1378LZjKampmjSgV++OL17B2TkyslRww8KCgpoQvxv37KBgw5TCuSk39+/owudPcu0cyeQ8a+q6t///99+/vyHFPQsLBwc6IawswOFgTQzBwcz0EJOThTjShYtQlNveO+ewYULQMYUb29xfv4iX19eJENZnsHiAQ6UP336BXbnk7dvQQ7794+yUJISFEQT4nv/ng3sbhlhYaCTmJhQDGX8+O0buhnnzrHu2AFkfKusZGZi4mZnZ2RkRGigeWoFCDAAU95RHGGi0hQAAAAASUVORK5CYII=</mdui:Logo>
+					<mdui:Logo height="37" width="80">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAAlCAIAAABanPmIAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyZpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMDY3IDc5LjE1Nzc0NywgMjAxNS8wMy8zMC0yMzo0MDo0MiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6RDA5OEREOUYzMTI2MTFFNTgzMkRGQkY0QjdEQjdFQ0IiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6RDA5OEREOUUzMTI2MTFFNTgzMkRGQkY0QjdEQjdFQ0IiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTUgKFdpbmRvd3MpIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6OTA1RkY1MzEzMTFBMTFFNTlGNzY5QkRDRURDMkMwNEQiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6OTA1RkY1MzIzMTFBMTFFNTlGNzY5QkRDRURDMkMwNEQiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz4lYPygAAAOWUlEQVR42uxZCXRTVRp+WZt9aZI2bZOmpNAttMWuYKllUcBhUVFAAXWEAeGIgqIC4uC4MIqjjjPOEUU4oOLCoohgoUhZS1u6t7R0X0PbNG2Tpk2brct8L6+Ets7R0VE8x/Ge15z7/nfvffdf7vd//yttaGiI+FXb4OCg09XP8WLfnNfR8ddqbL9SUTVS2ttn6x8YwFZgDnRwOZ0ul6sfj1z95K+hvSOroBj9gtLyIfemrb19be2dHh2oYZiChoUsPdayqpprrW0QYjxlZZvdgd+M3ILzWTk3zb5M/GGj9deaI8NCahqaHE5nS1u7RCT0lojTM7JCg8cJ+PxOc1ezoS0qLIRGo53Lzl2xZKHD4czOL4qPmlhb39Df7yqrqh2nDoBiMITD5TS2d3b1WJUKmUQobDG2awL8/Hx8Dh1P02rUt8ZOqqipi4ueKBIIjqef14UEV9TWjw8KvGkKkx5msZgms6XpWkth6dWcnPy002cVcu+quvrzWbkMBmOov9/UaRp0udpaDXs+PWS2WAaHBn3k3gwm40JOXq/DKeLxWASReTk/WBN49NSZy4UlVTV1Pb29rS0GIZcjEgkv5hZ0mM1ioSBYo9a3Gg6nnlIq5IVXrrYZ269W13qLRdpA9U1TmIbosjscaecvhWiDbHZ7e6c5fIK2xWBU+fnqWwzwCZfDgZIIawGf12rswODEW6Iws7CsAgchJTHOz1dhMHZYenoiQ0NKKioxnsfldpjM/r4+XmyW3emsrK2PDg+91mrgcLxqG/UI7EcW32Pts53NzAkLDpKKRWwWSyQU3DyFbyZE5ZaUBgeqcV5+LYwcVpjCGBaTOQo/8WxwiMGgeyQUPjHo9IGBgZpGvUrpy+dx/3eUprkbYJFG0HC+fvEzjAZEwYVOdX2j2dINdEVMFpWVf/51KuC3z2ZvN5nxNCu/6Pjpc+jgrB45cRraYlhlbUNbewfGILDxCEGLsAfO1zTo++x2DACYtXV0UiCPp1gfGQAvwm1Pb9/B42nGDhP6nx1NTT17AZ2WNuPJcxnNBqOVfLPj50dptKq6hm5rb/h4LfYBQLI7nMBbpCuVnxIwg6fYKLAUcO0tJqMRZ1ssEmYVFNU1XrstMQ5Q3JBfBIX9lT5AXaA3QiZI5Z92LqOpuRWHHxquXrYIWeBcVg7WxOJNLa042GKhEMFCo9PcoFAeMSEYBz63pMxk7gJeor/snnlcjtfP7GFkwgnjAlMmxwG6hAI+cma31QrTQj1sxNRlgc6+ChksAuzluF8fHR52Kbdw50cHSLwR8AHyyFsybyniM1QbZOnuhuG8vNjQEMcECa/hWgvWAbB1dlngbThZFzK+sLTc1NUFcwCoM3IKYnQRQj7/wPGT0ybHBwb4AfAAomMIws9zhrEt6OkrlyFQEZ9PrFh25ORph9N1z5zboblSLm9uM0Kf2MiI9Izs4CB1WLD2alUNfD7/junYKJvNSpgU2aBvxjAgPIgGgBdJrrmtHUHRajQGqQLAOuKidEDv9EvZXmy2NlAFB/K5XMhh31m33YrVZFIJWErjtZbYKB3shSgABQBMKGTSXwqloR7ukDDbO03IE9gZ8ZtrtF+dS9/kRif+z9rvCv/Wm7ta6ugEiU+cFAkURUUIdgFk9FQweSVl7SYTnUZH/gAae9gYgA21IQoJ1D0J0ZFgSMi9lwtKMFHpI8eA0spqFFWAXGo8ABkITKfTpWJhfHQkOpS8rulaeU0tmJZKqYwKD4Gkq7unqKwCqI43AmKyC4q9pRJkOzzKzC8KUPqi/EIfWRrpbXJMNPrl1XXIYTGRER7FSiqqkP74fJ61txeLgz4hO6KkI0vTvQePEEIVMh5VSLC10as3vTDkbq/v3EP4hcijk/xiUwhF8NrnXqLkyBlh0+YSqnDNlNsJSeBdK9ZBCFpEV+ve23+AGjNr2arQlD9Q/f1fHmNqIsXhCQHx0wmx+qENWyg56gdJRCJvQozvLcmQb3/nfQjPZF4mpJrc4itUNS4Mi3tw/SaS5g4O8kNit73xDjV32ePPyCKnUP2Fq57QzVgwNKL96dlthFyrip/uHzcNFyFSvblrL+Sku5B+2D4yFotFojaNJpd5w7ToF1+tfHbLi6++8udNj60EMTz27dn7lq+eOzNl7ozbVmzcCvbQkH1aE+C/5/Mvzly67JnL9RomRsjGyHPuWDAvf3TDi89t3LZhLW6hfF5JKTVmydqnJsdGH93zLzj82e1v9Fh7KUrPUwzvh06jKcj98Knxcm8p7zp7FwoEoDpUH0lUKhGNDN33X/tLRW0dtnTh0EfkHkwmGo0+HNJMJoPNZFXXNfr5KEBCaEME252B4W26SBgXrQOnB6NC8EgD/O1ucgtNYqMioC36K++/Fxf5BcNmA7sG37B0g6jZsXtQC8hRXRJOJ0mwbTYUHssXzscFORkRDDqOA9ut21vbNnm268UiWZpWra5r0uOUeT4AYauM62cBHdxd7zM8/WFwotFkEomxoxNvwXs5Xl5Ct9VIhTlsLxSxa7e+5HA68W6L1SoRCakPAwwGE0F1vawZwjuoaobL4YIej83pdDoO2N8/2Pf27g9hTpvDfu+dd0COSnv1mhUff/H1zo8/R/kFF81IStz75nYelwM3fncdRJxAwF//wquon+BtGHdEOUn77/EJpB2hF5w8x1Bbv3nzk69u2jCsMGp0OOS9V1+YmhADinffoxss3T2QYys4ODDe8Kto8P0QpT/Q6LuFIQ4ZCp3HH1m+aukiu8O+ZstL+haDJ8DIuOixouo6/M2pzc+/vO7hpQgZVA4jy0+qOZ0uYMy72/8MuzToWxavfdLc1U0VkhjvQTtsyGMsbIyK2JGtxdCGauT4hzuxGgj/jbQ04P5eNzF0go/MG4QZbqVKORIzOkxUHUciYU1dp76ZsjCYMECOjFWC+Cb9/NOv/A0dgDwMhyJJqZCBP8MtuIUcbPmpl3ZcqagWub/yJCfGUivgF1sprayh1n97z0ckRpKKECDV2Cv2Ex+tQ9A5XC5qCkpVADg1vqKmDree8MaRQUSYuyzQE13ScK5+8Hy5VIItITBhboLSatcnBwlCUny1An2y/lSMf3D9Zgrrnn75dUKiEYXHSyOnECL1kjVPUvLKugb/ScnAbZ+4FIKtSF5wP4XwhDTonb2fUGOSFy4PiJuOjmtwIDRpFsH3U8Qki3WJAMzVz2yjxqAIZwXqGJqJ5Po0CV4HYXpGFsGUIRtRKE2oIhB01PgDx04ga7DGRTI1E9mBuq9OpVPyx7a+jG14R07BRbDlb+7aB+FdKx4jeEqPcMe7uyEkuTTK3VMXMpfdPVcqEcPZ+w4dwalLTiD9AEsfSj3VZuxAIPF5vCXz51AATjn8xNmLwAag5aJ5s5CNoTAQOCk+BnU1BuApysnF8+ZQSftw6rdYDaEEzy+aN8eDQxdz8qEb8jzqsLtnz4QEpT/qtkXzZiu8pdjeh4e/QrxMm5JAjT+beTm3uBTjAe9T42MoYU7RlZyiEiaDiXOHqnbO9KkxEyNQe5dV1ZIgR6OhwJ6dkgRS8Hvx8LvCv0EuXVTXfPB8wYZ7pvtIbnwcfj/1EuB65ezJJA1ubN2fnvfkwmk+EuEHJ7KyyuvlYgHghM1ihql8/nhHYr2h859HL2iVMqOlp8/usjmdAXLJ1vtn5VY17T+Tq1XKWzotzv6B/oHBxSmTknXB5EHttLx77KJaIX10bhKQf9eJTDGfu+S2W0btbtMmQq8fJfn007FytZrYsYPsNDcT+/YRZWWEREKsWUNERRFLl46a6x5JerjN3H26qKp39PfBvGp9Qc3wosYu67dFld02coC3kAdllFJhUoQW2etkPpkkfKUiYEFq3lVQlVCVj0ou9RWT1EUpFZmttvNXatDRaZRcL9b2z05V6Mn/MFltjqyKhr2nsnMrybSXX62HWce6Y/Zs4oEHyI2ioYNrZNu8mbxWrRq+hbbQGZL77iNUqlFTsAI6WI3yMJfN8vcWj6FmchEfu6f6HPcABo3MwfdOjcZFyUsbWxuM5BdWnhfrwdvjX9x/cum0uPH+8hs2VUgWTJ6YlleO6CA/ytrsy3d8DIXD1L6A03C1b5fVll5UlRCqgQXh4bEKz5hB/mZkkL/z5499GhU16hbaCoXEhAk35NSUzz4bOf0nfvU+U1z92oFvYZEtS+4YTv00GpfNPHihkMNmwoIr50xhu+0F9mi1O49mXwny8S5vauu22f3lJE/EieCwmLDdoYtF7RarhM/90dmipIT85fGI8ePJTkoKcfQosXEj6WHKUt/zXfoHPnxRl9vDjUYzVC2s1S+dHrf6ziSo5yF6yNWd3VbXwCB85cl2GODqH/gyo7jRaJKJBJsX354QoqGIamdPX5JOm1elP5JZgqrgu6T6B9prr406w0uWEAoFcfgwsXv3jej4jwoPudkcnT6Kl/fYHBI+53pVQLPaHZQO2z5KZTHp2W9vHLMQPAYUWDsveWRIk7yy145jv2v9/f/46vzpwkpEr+eRw9WPgzM3MWLXiSy8KzLI/8cpTAHYmCMwaRKxbh2RlvZ9CoNJm6193+SU4aC2d1vxOzs2LCE0EMj8cXpugEz8RWaJn0w8Tilz/8MJDuTnVTfVG0y9dqdMxJuXoIO7+geGLH12qFRn6ECIingcSt7ncAK6MXH93SnFdc0r3vr0qYUzkidqYb6ObqsJTo7QAvkxMWqc/08Jac9hPnaM9DDFrmNivi+k5SJB7AR1aUNLfnVTd689PFAJhR+amYBEkpZfDmomEXD/+vA8asJUnRZYtSs1k8mgQ0ONQjoXiqHcF3ATQzVXmwzA9l6H0yP3lQp1Gj+UXSChLyyb8/yH36TmlkFhMZ8DDfvdYYxsBG/7SoQ/JaQ9rob+VE6aOZNYsOD379LD7d8CDAD9/NQaNdOgigAAAABJRU5ErkJggg==</mdui:Logo>
+					<mdui:InformationURL xml:lang="en">http://english.hslu.ch/</mdui:InformationURL>
+					<mdui:InformationURL xml:lang="de">http://www.hslu.ch/</mdui:InformationURL>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:IPHint>147.88.219.232/29</mdui:IPHint>
+					<mdui:IPHint>147.88.220.0/24</mdui:IPHint>
+					<mdui:IPHint>147.88.221.0/24</mdui:IPHint>
+					<mdui:IPHint>147.88.217.218/31</mdui:IPHint>
+					<mdui:IPHint>147.88.222.0/23</mdui:IPHint>
+					<mdui:IPHint>147.88.224.0/24</mdui:IPHint>
+					<mdui:IPHint>147.88.225.0/24</mdui:IPHint>
+					<mdui:IPHint>147.88.226.0/24</mdui:IPHint>
+					<mdui:IPHint>147.88.228.0/23</mdui:IPHint>
+					<mdui:IPHint>147.88.230.0/24</mdui:IPHint>
+					<mdui:IPHint>147.88.231.0/24</mdui:IPHint>
+					<mdui:IPHint>147.88.232.0/22</mdui:IPHint>
+					<mdui:IPHint>147.88.236.0/24</mdui:IPHint>
+					<mdui:IPHint>147.88.237.0/24</mdui:IPHint>
+					<mdui:IPHint>147.88.217.220/30</mdui:IPHint>
+					<mdui:IPHint>147.88.217.224/27</mdui:IPHint>
+					<mdui:IPHint>147.88.238.0/23</mdui:IPHint>
+					<mdui:IPHint>147.88.218.0/25</mdui:IPHint>
+					<mdui:IPHint>147.88.240.0/21</mdui:IPHint>
+					<mdui:IPHint>147.88.254.64/29</mdui:IPHint>
+					<mdui:IPHint>147.88.254.72/29</mdui:IPHint>
+					<mdui:IPHint>147.88.254.80/29</mdui:IPHint>
+					<mdui:IPHint>147.88.254.96/29</mdui:IPHint>
+					<mdui:IPHint>147.88.254.112/29</mdui:IPHint>
+					<mdui:IPHint>2001:620:110::/48</mdui:IPHint>
+					<mdui:IPHint>147.88.218.128/25</mdui:IPHint>
+					<mdui:IPHint>147.88.219.200/29</mdui:IPHint>
+					<mdui:IPHint>147.88.219.208/29</mdui:IPHint>
+					<mdui:IPHint>147.88.219.216/29</mdui:IPHint>
+					<mdui:IPHint>147.88.219.224/29</mdui:IPHint>
+					<mdui:IPHint>147.88.0.0/16</mdui:IPHint>
+					<mdui:IPHint>147.88.216.0/26</mdui:IPHint>
+					<mdui:IPHint>147.88.217.0/25</mdui:IPHint>
+					<mdui:DomainHint>hslu.ch</mdui:DomainHint>
+					<mdui:DomainHint>hochschuleluzern.ch</mdui:DomainHint>
+					<mdui:GeolocationHint>geo:47.046681,8.314912</mdui:GeolocationHint>
+					<mdui:GeolocationHint>geo:47.013434,8.305034</mdui:GeolocationHint>
+					<mdui:GeolocationHint>geo:47.174274,8.512537</mdui:GeolocationHint>
+					<mdui:GeolocationHint>geo:47.060845,8.322106</mdui:GeolocationHint>
+					<mdui:GeolocationHint>geo:47.048388,8.309762</mdui:GeolocationHint>
+					<mdui:GeolocationHint>geo:47.048096,8.314655</mdui:GeolocationHint>
+					<mdui:GeolocationHint>geo:47.054246,8.295853</mdui:GeolocationHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDKDCCAhCgAwIBAgIVAJJ0EFhAwfkkeh7c61vcoGwHtCfeMA0GCSqGSIb3DQEB
+CwUAMBoxGDAWBgNVBAMMD2lkcC5oc2x1LWxhYi5jaDAeFw0xODA2MTkwOTIwMzRa
+Fw0yMTA2MTkwOTIwMzRaMBoxGDAWBgNVBAMMD2lkcC5oc2x1LWxhYi5jaDCCASIw
+DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOG5iU7LrIEVui+nzgB2I66c0Wsn
+INfWuUlKJIWBvGqKyy8WyNoXnhV7ft5RHez7Y7y1btJ1Wm29XvS8MF2Ni5zfVc0f
+W1yun6nKCi2Xt7h8Rwfh0YksDRhlywJpK/tjgOSTpcZyu/7HC8gf6lEZyYJRGJ4L
+Vih72ulq4kAinpJnbiakM4AhmlT7MEPYfaGlxedchhpFNUh1gi5Ih1z1q4NfM3vN
+ydN3DdWa0x3RBQXmg1khvVnLVyhTpGoXSndnOJJsRsx21+qyhz259S1IlolHexSs
+JPgmH/XAERXqviwKFAfbDmCGGE1ZnMM6C3++WgQvI/R8L/A/DWifwCMJsiECAwEA
+AaNlMGMwHQYDVR0OBBYEFEbkcoOYCpU35FcN26RV7LO+T5DBMEIGA1UdEQQ7MDmC
+D2lkcC5oc2x1LWxhYi5jaIYmaHR0cHM6Ly9pZHAuaHNsdS1sYWIuY2gvaWRwL3No
+aWJib2xldGgwDQYJKoZIhvcNAQELBQADggEBAD7r30A7VSFmdE/WiZBLTzNu3dPU
+BIBWGwwP/uL5YIouXtRfVS9jWbvMtBqFX5SLHLlVrGv7Ksa4zSnHgq5c85N+D3xH
+rPrdWNdtO4GPXMA6SOFgjA92SCCSqFubDKo8sPUPFBVPZkjTh6cHAqDVj/pxKjJ9
+GCqIUxFGID9QPkF5lxTZTM6cUOsXO4ugOIQZIqApOm5kHn6hTVyz3oyCvFRRgf20
+KseYmjisPXK1pFqRHXuCc2guAc/zXr8S6DDBHXvfg9/T1uobSsxS+55TecX8A+sd
+yhtEPzc4dxhh5e6U3pfMqkFkAiEKsg6TnGbEVQuDMy5922C83RMUqT4z3kA=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp.hslu-lab.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="1"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.hslu-lab.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.hslu-lab.ch/idp/profile/SAML2/POST/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">hslu.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDKDCCAhCgAwIBAgIVAJJ0EFhAwfkkeh7c61vcoGwHtCfeMA0GCSqGSIb3DQEB
+CwUAMBoxGDAWBgNVBAMMD2lkcC5oc2x1LWxhYi5jaDAeFw0xODA2MTkwOTIwMzRa
+Fw0yMTA2MTkwOTIwMzRaMBoxGDAWBgNVBAMMD2lkcC5oc2x1LWxhYi5jaDCCASIw
+DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOG5iU7LrIEVui+nzgB2I66c0Wsn
+INfWuUlKJIWBvGqKyy8WyNoXnhV7ft5RHez7Y7y1btJ1Wm29XvS8MF2Ni5zfVc0f
+W1yun6nKCi2Xt7h8Rwfh0YksDRhlywJpK/tjgOSTpcZyu/7HC8gf6lEZyYJRGJ4L
+Vih72ulq4kAinpJnbiakM4AhmlT7MEPYfaGlxedchhpFNUh1gi5Ih1z1q4NfM3vN
+ydN3DdWa0x3RBQXmg1khvVnLVyhTpGoXSndnOJJsRsx21+qyhz259S1IlolHexSs
+JPgmH/XAERXqviwKFAfbDmCGGE1ZnMM6C3++WgQvI/R8L/A/DWifwCMJsiECAwEA
+AaNlMGMwHQYDVR0OBBYEFEbkcoOYCpU35FcN26RV7LO+T5DBMEIGA1UdEQQ7MDmC
+D2lkcC5oc2x1LWxhYi5jaIYmaHR0cHM6Ly9pZHAuaHNsdS1sYWIuY2gvaWRwL3No
+aWJib2xldGgwDQYJKoZIhvcNAQELBQADggEBAD7r30A7VSFmdE/WiZBLTzNu3dPU
+BIBWGwwP/uL5YIouXtRfVS9jWbvMtBqFX5SLHLlVrGv7Ksa4zSnHgq5c85N+D3xH
+rPrdWNdtO4GPXMA6SOFgjA92SCCSqFubDKo8sPUPFBVPZkjTh6cHAqDVj/pxKjJ9
+GCqIUxFGID9QPkF5lxTZTM6cUOsXO4ugOIQZIqApOm5kHn6hTVyz3oyCvFRRgf20
+KseYmjisPXK1pFqRHXuCc2guAc/zXr8S6DDBHXvfg9/T1uobSsxS+55TecX8A+sd
+yhtEPzc4dxhh5e6U3pfMqkFkAiEKsg6TnGbEVQuDMy5922C83RMUqT4z3kA=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp.hslu-lab.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">hslu.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="de">HSLU - Hochschule Luzern (Test IdP)</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="en">HSLU - Lucerne University of Applied Sciences and Arts (Test IdP)</OrganizationDisplayName>
+			<OrganizationURL xml:lang="de">http://www.hslu.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="en">http://www.hslu.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- HSR - Hochschule für Technik Rapperswil -->
+	<md:EntityDescriptor entityID="https://aai.hsr.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">hsr.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">HSR - Hochschule für Technik Rapperswil</mdui:DisplayName>
+					<mdui:Description xml:lang="en">University of Applied Sciences Rapperswil (Test)</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDFDCCAfygAwIBAgIVAIauIVAbytJ6Ru9afYPmcs7A4fg1MA0GCSqGSIb3DQEB
+CwUAMBUxEzARBgNVBAMMCmFhaS5oc3IuY2gwHhcNMTYwOTI5MTAxMzA0WhcNMTkw
+OTI5MTAxMzA0WjAVMRMwEQYDVQQDDAphYWkuaHNyLmNoMIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEAwEfD6uudjNJdpWNiKsZVtLVCoSMRqBNjCg6c9kU+
+QSAbGBMgYTdhkna1wqskIbrUUwFqDWLdYK7VcvMvVAp7PLHQsUEKNeYVS7yk+fAX
+3TqnkWtUiI0v6tUMTdgw31jO8t615qql6xIqzQhqWDa86wlO2nK7NSLHoCRWsytc
+biBLJSYyOBi1M/Sp7l+HajBQM1wlEzOLmIq9QcinE6wst1gcc0bH6AfJgY9SScC2
+c7Hv8mMFw5eSzT3HjcXicTJ2Odo9GbjZiNS5CdNHay6sZILhjof/RokC5zu8atCI
+ytNxL/ZzXa/Tn6gzcl0e61bpOGd0zrZCG+4SGlI/b88FMQIDAQABo1swWTAdBgNV
+HQ4EFgQUJqVgcLiKBQjVw1F7LWXyv1y6xlAwOAYDVR0RBDEwL4IKYWFpLmhzci5j
+aIYhaHR0cHM6Ly9hYWkuaHNyLmNoL2lkcC9zaGliYm9sZXRoMA0GCSqGSIb3DQEB
+CwUAA4IBAQAb3WKVFW2RL1dGfnaIbeYygMq/6C7HszMIu2wCsIvDeMpBmth/Y5Ii
+KlIrWHrTF/r0YKrIADIzgbL5jdgEgsMDbuJW+jT3Y3RqeWjd9SF19tU38whKISrE
+QFgAbYjMHHpfUfaiAHT24X9dtLqDkdS0IVdGErhVt3cIX9kmhyaABVsn3vgYx9JE
+nKRpNMooKD99Ni61hSeUx0xA7VfgjTiZz8lYpUM0lvXbrGuTzXismGv3O8RA3TE5
+s/TC3zuj7Xc9Z7OKcammvr1A9Fsur/jpsFR4xPl2x2FtY2tpXphQNIA4scB6lQ3X
+jy1NpjCN4pndPueRmR7J9VMMN1ARCpsJ
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai.hsr.ch/idp/profile/SAML2/POST/SSO"/>
+		</md:IDPSSODescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">hsr.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">HSR - Hochschule für Technik Rapperswil</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.hsr.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- University of Geneva Lab Identity Provider -->
+	<md:EntityDescriptor entityID="https://idp-lab.unige.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">idp-lab.unige.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">University of Geneva Lab Identity Provider</mdui:DisplayName>
+					<mdui:Description xml:lang="en">University of Geneva Lab Identity Provider</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>idp-lab.unige.ch</mdui:DomainHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDKzCCAhOgAwIBAgIUPnGNWmashu8T2D9vQ0NvCHntNZMwDQYJKoZIhvcNAQEL
+BQAwGzEZMBcGA1UEAwwQaWRwLWxhYi51bmlnZS5jaDAeFw0xOTAyMTkxMDU4NTha
+Fw0yMjAyMTkxMDU4NThaMBsxGTAXBgNVBAMMEGlkcC1sYWIudW5pZ2UuY2gwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCPL4WnbRP8nnEQLz/xN1G0Ffg+
+kAI9Dad7roFHqcVg0uYb4hbmXXC2JKzW24ti8eDdznCcgNXwt159rn17coIu5We5
+aOeLEq+LFEz+md6rn1het+jQoTTD3rnOQL/W0gktuo6enOzkiiHPXVqLBVmrSzZf
+h1kmymhSHZ1CQfcupG+keIbhBa0l2XqQTLDZQiyEIhGhPbjcEhyyUejuHrVxtquC
+VFo58X5BjGwlJTwTUxyZYvAaFrnVyL0uzaboj0vwBD9T8NxUPB3HmZVHg5pzPHUn
+smi+ULTtzfBp1vurN68r0//cLvm0b3GpkYfPntO4hGWcq1hOi66olOsIEXPBAgMB
+AAGjZzBlMB0GA1UdDgQWBBQQzWIU0mUPsOODT4Td/r8l5+8rFTBEBgNVHREEPTA7
+ghBpZHAtbGFiLnVuaWdlLmNohidodHRwczovL2lkcC1sYWIudW5pZ2UuY2gvaWRw
+L3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQADggEBAE4Prfgx50CJZdBmWrGNgQI8
+cFVEqpHimBYhN0Q4jTAzc5VwjEqGCP1Env0pGpQNwBMQpd3Wz6Mzp8NHp1Rc8Nve
+swT/j23DQnl2M8TLkuNA2yffzoesNZTVRrlFlnvt48YY04Zh3bDn1Za6M+ixKz61
+17gIdDJ4vC4rzo82SuiSsoJ0r2QD3AamBpc4yb2zYzIvS2R1xQQ+eVzmWJMz8HNy
+qMLi+aI4EFIaYQqgdCKHIAyOqoLdxmsoUmRzcDO8APQ6GwTog/8MqsYWzuGx2Z22
+ifJgPU+WUNfbazu78ifV63eAtUl+nBkhi5gMinY7oXtD0vK69FnXB2oZJHp3o5k=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp-lab.unige.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp-lab.unige.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-lab.unige.ch/idp/profile/SAML2/SOAP/ECP"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">idp-lab.unige.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDKzCCAhOgAwIBAgIUPnGNWmashu8T2D9vQ0NvCHntNZMwDQYJKoZIhvcNAQEL
+BQAwGzEZMBcGA1UEAwwQaWRwLWxhYi51bmlnZS5jaDAeFw0xOTAyMTkxMDU4NTha
+Fw0yMjAyMTkxMDU4NThaMBsxGTAXBgNVBAMMEGlkcC1sYWIudW5pZ2UuY2gwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCPL4WnbRP8nnEQLz/xN1G0Ffg+
+kAI9Dad7roFHqcVg0uYb4hbmXXC2JKzW24ti8eDdznCcgNXwt159rn17coIu5We5
+aOeLEq+LFEz+md6rn1het+jQoTTD3rnOQL/W0gktuo6enOzkiiHPXVqLBVmrSzZf
+h1kmymhSHZ1CQfcupG+keIbhBa0l2XqQTLDZQiyEIhGhPbjcEhyyUejuHrVxtquC
+VFo58X5BjGwlJTwTUxyZYvAaFrnVyL0uzaboj0vwBD9T8NxUPB3HmZVHg5pzPHUn
+smi+ULTtzfBp1vurN68r0//cLvm0b3GpkYfPntO4hGWcq1hOi66olOsIEXPBAgMB
+AAGjZzBlMB0GA1UdDgQWBBQQzWIU0mUPsOODT4Td/r8l5+8rFTBEBgNVHREEPTA7
+ghBpZHAtbGFiLnVuaWdlLmNohidodHRwczovL2lkcC1sYWIudW5pZ2UuY2gvaWRw
+L3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQADggEBAE4Prfgx50CJZdBmWrGNgQI8
+cFVEqpHimBYhN0Q4jTAzc5VwjEqGCP1Env0pGpQNwBMQpd3Wz6Mzp8NHp1Rc8Nve
+swT/j23DQnl2M8TLkuNA2yffzoesNZTVRrlFlnvt48YY04Zh3bDn1Za6M+ixKz61
+17gIdDJ4vC4rzo82SuiSsoJ0r2QD3AamBpc4yb2zYzIvS2R1xQQ+eVzmWJMz8HNy
+qMLi+aI4EFIaYQqgdCKHIAyOqoLdxmsoUmRzcDO8APQ6GwTog/8MqsYWzuGx2Z22
+ifJgPU+WUNfbazu78ifV63eAtUl+nBkhi5gMinY7oXtD0vK69FnXB2oZJHp3o5k=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-lab.unige.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">idp-lab.unige.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">University of Geneva Lab Identity Provider</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.idp-lab.unige.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- University of Geneva Test Identity Provider -->
+	<md:EntityDescriptor entityID="https://idp-test.unige.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor errorURL="http://www.unige.ch/dinf/ntic/aai/errors/error-origin.php" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">idp-test.unige.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">University of Geneva Test Identity Provider</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="fr">Test IdP Université de Genève</mdui:DisplayName>
+					<mdui:Description xml:lang="en">University of Geneva Test Identity Provider</mdui:Description>
+					<mdui:Description xml:lang="fr">Serveur d'identité de test pour l'Université de Genève</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>idp-test.unige.ch</mdui:DomainHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDLzCCAhegAwIBAgIURE4/bO64QeKkZpysUpeZN5/Jw0kwDQYJKoZIhvcNAQEL
+BQAwHDEaMBgGA1UEAwwRaWRwLXRlc3QudW5pZ2UuY2gwHhcNMTkwMjE5MTA1NzE4
+WhcNMjIwMjE5MTA1NzE4WjAcMRowGAYDVQQDDBFpZHAtdGVzdC51bmlnZS5jaDCC
+ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMhlbd1r/m1wUOrmSdEGK5Mt
+o5pAMUnRg0jCgD/4hOtHPc/ym/UThvrrUKHBEs+FWdeaz6JPEc+qFfIxW7DQ+Dog
+doGAs+NlgmW6FPhCVcOiAvCXmkr68GsUuWNB94avq3B/XhVhDApyZTgXXa88lMYi
+73uNi0lG/JRCaKkk7MKsTcb54/+iYdDEwYYpCUXtBobBtbSHoM7+1CtByP37CqBL
+rW+qOyKbnUd57k9QoFtlzEPGIDzlluuriznoOSQNe7OUIzOM8YO+6wA0V3yPnZBl
+s/W8OWsnt52lXjDht+T4//dBvh0ZljCGntu3L3LHq8uW752nCxr25clxHOJM+cUC
+AwEAAaNpMGcwHQYDVR0OBBYEFFqC3VZWZ6khzyl+zLPQ42cONLZ2MEYGA1UdEQQ/
+MD2CEWlkcC10ZXN0LnVuaWdlLmNohihodHRwczovL2lkcC10ZXN0LnVuaWdlLmNo
+L2lkcC9zaGliYm9sZXRoMA0GCSqGSIb3DQEBCwUAA4IBAQBmvCliZi1zw+qfvol0
+XaMTr+hcc0Xys493+P7EZ1Ma1N3r+3xBAOzQM8QYgwcEXy8A8B85YvmJIiNtC2Et
+tymONsmqIcdmU8hupKPC/vkwqtExhkLerfaF4nQEBLmOBWgAQQkMHFNsJwgX1M4A
+IRaqM6ZRvcBGfhH+pVHT7bQ8rRLbvUFqz1D9vPcxeIBPJ7I9VKD/KaP83u/rqpJ1
+GRfWmNMY23uWHQkC+1ar4gXe8RzcsLgpGHxueLejLDo9nhKmphUkb4kdaqkjUqB7
+8SkFRe/mSc50tNrhNpmXckxJps6HLb4hG/Fn+KN4HfqFdCooEe4XMRKKSwwRDqFD
+Ofim
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://idp-test.unige.ch/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-test.unige.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://idp-test.unige.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp-test.unige.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp-test.unige.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://idp-test.unige.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-lab.unige.ch/idp/profile/SAML2/SOAP/ECP"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">idp-test.unige.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDLzCCAhegAwIBAgIURE4/bO64QeKkZpysUpeZN5/Jw0kwDQYJKoZIhvcNAQEL
+BQAwHDEaMBgGA1UEAwwRaWRwLXRlc3QudW5pZ2UuY2gwHhcNMTkwMjE5MTA1NzE4
+WhcNMjIwMjE5MTA1NzE4WjAcMRowGAYDVQQDDBFpZHAtdGVzdC51bmlnZS5jaDCC
+ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMhlbd1r/m1wUOrmSdEGK5Mt
+o5pAMUnRg0jCgD/4hOtHPc/ym/UThvrrUKHBEs+FWdeaz6JPEc+qFfIxW7DQ+Dog
+doGAs+NlgmW6FPhCVcOiAvCXmkr68GsUuWNB94avq3B/XhVhDApyZTgXXa88lMYi
+73uNi0lG/JRCaKkk7MKsTcb54/+iYdDEwYYpCUXtBobBtbSHoM7+1CtByP37CqBL
+rW+qOyKbnUd57k9QoFtlzEPGIDzlluuriznoOSQNe7OUIzOM8YO+6wA0V3yPnZBl
+s/W8OWsnt52lXjDht+T4//dBvh0ZljCGntu3L3LHq8uW752nCxr25clxHOJM+cUC
+AwEAAaNpMGcwHQYDVR0OBBYEFFqC3VZWZ6khzyl+zLPQ42cONLZ2MEYGA1UdEQQ/
+MD2CEWlkcC10ZXN0LnVuaWdlLmNohihodHRwczovL2lkcC10ZXN0LnVuaWdlLmNo
+L2lkcC9zaGliYm9sZXRoMA0GCSqGSIb3DQEBCwUAA4IBAQBmvCliZi1zw+qfvol0
+XaMTr+hcc0Xys493+P7EZ1Ma1N3r+3xBAOzQM8QYgwcEXy8A8B85YvmJIiNtC2Et
+tymONsmqIcdmU8hupKPC/vkwqtExhkLerfaF4nQEBLmOBWgAQQkMHFNsJwgX1M4A
+IRaqM6ZRvcBGfhH+pVHT7bQ8rRLbvUFqz1D9vPcxeIBPJ7I9VKD/KaP83u/rqpJ1
+GRfWmNMY23uWHQkC+1ar4gXe8RzcsLgpGHxueLejLDo9nhKmphUkb4kdaqkjUqB7
+8SkFRe/mSc50tNrhNpmXckxJps6HLb4hG/Fn+KN4HfqFdCooEe4XMRKKSwwRDqFD
+Ofim
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://idp-test.unige.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp-test.unige.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">idp-test.unige.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">University of Geneva Test Identity Provider</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="fr">Test IdP Université de Genève</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.idp-test.unige.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="fr">http://www.idp-test.unige.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- libraries.ch Test -->
+	<md:EntityDescriptor entityID="https://login-idp-test.libraries.ch/idp/shibboleth">
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">libraries.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="de">libraries.ch Test</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="en">libraries.ch Test</mdui:DisplayName>
+					<mdui:Description xml:lang="de">libraries.ch Test</mdui:Description>
+					<mdui:Description xml:lang="en">libraries.ch Test</mdui:Description>
+					<mdui:Logo height="16" width="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAALpJREFUOBFj/PJly/+XL4MZ/v//yYANCAm1MQgIVGKTAosxcXF5M0hIbGZgZOTGqQifBBNIkpPTlUFSkjxDwAaADOHgcCTLELgB5BqCYgA5hmAYQKohWA1AGLKFgYkJf+ww/vv3/z9IAy7QeOE2w61Pv7BKK/FyMrBglYEKZp+4yTDn1jOcSoyFeRlweoGQZpipWA0gVjPIEAwDSNGMYQCpmlEMIEczyABgLPxnyDtxi2E+MLSZQSIkAgBvqDxf8SowAAAAAABJRU5ErkJggg==</mdui:Logo>
+					<mdui:Logo height="61" width="80">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAA9CAYAAAFNfN6/AAAACXBIWXMAABAmAAAQKAEdNWGbAAAKGUlEQVR42u1bCVRU1xn+3sybGYZlYNhkGfYdDgQBZRM0pyaujVbrkhht7Tm2jU3TxLaJSbStUWNNojEndrFZ1Bw1NQnYRm1MNOLGZkViEFAQHBBw2JEdhpnpvXcWNrWoeCA575/z5r2595///fe7/3/v/d9/H28wGHoBSPB/iMcI6Z4Y73pbg6EPffpa8JWtXXgtpwR/nx4FdWsnjpTX4fkYPzR29cJJLgXH8Uj9RA3eWyHXvv/4I0xqoIMNY6JEmcyU/WTyw2gMwdEw6vCMDmNelQNiVS3g12dehZOVFLP8XRCitGWVnX06WPNidk2ZEj/OBL8xOWSYFDPTw8dxRPY46nceO4HEvCU5mmbk17Virr8rsVxb7Mgvw5bkMKzPuoqNSSF46WwxPGys8Byx6KPltUjydMSOvDK8lhRqEaTVVUMi9mRuAHosDvawVFJhlKgwSltTwix1c/0nsPNAYdQOjKRmTdY+aKdQe/kOdcpI/fl7ZIeCwHumC1UKcBCxkZMJrGnvhoetFX5/pghPh6kg4oC0Eg1SVU7I0TRBTApeigtk9W+mhmPNqUJcaWrHdF9nrIkJQJyqlQkdpiFlPqauA7XK1dE++LDwBjIqG3FsQbxpsgROVjZg+7QIzErLRVtPn0XIzZ5rzJ8N5MNT7cw009fVcr12UiA7zPTW1HDL9RcL4y3X9MbvfVs5ehj+LMKLHYIdjvPxcFTn5XHfYkFBQcH7UHBMHaSnT02+RZbfMt6TfPev2/kKEj3xIhHeJkvHt6ZG4LenirBtWviIhKcezMKZJUkjVmb6p9k4sShxUJmM9yUzlQ551Q5k3hQjyr2QLVktCnKgH0DOG3u7pKWDnX93ugjTfZzRq9PjiQA3dPXp0dDZgx69HquOFyBjUQJkYhF2F1ZifoA7aSSH9GsafEmmzAOzY4yTtaYFUsIT5aIgcaUB3TodK381sxibk/uXwxwnJvNwG51U0dxdCYneOJXS9SDvbivDnEPnMcvPOHVSYcn/PIcFge6wlvBESSU6tDo8np6N5aEqwjcBT4Ua1+H0vysjvLHyy3yUNHfiwxmP4HCZBo+nZbPY1koixp7LN3C2qhEbyDo91NHO+D9rq2Ho7i+uxs5v1KZfVSYFyfwuId371cIEC+NmFssNjud4cqPMJVMsv1dFerPzRzMnsvPuGRMtdZ/9MG7QfweuC2aaQHh2op+lrJCsZg6V1jC45vi5DI7oTU6iHUtHiXC0RUR8sDAOCgqOXwVHO/wcZeoVulhQUFBQUFBQUFDwO6yg3tALrU7Tv/QnHynvNZBFOqYKijgpatq2oqljv6lEglhV/WAEwz86haIV07D27BVISPS3MTl0RMJbuntR0NSGFA+nEfEfvFqDJSEew8r9lH8hsZwN6jv+cfsuppEZpZgJChQ3tuOYup49rHwjNQxbzpehV6/DbBJLHCiuwprYAJwmAVCQgw3CnOzgKpeRKEyLjTlX8ctoP/gprPHimSIsDfVEvJsDi+RoBOdqLYWPnQ1osvDdfDVeTwklYHAWJbyVb5DIToq69l13tsGC+jYWOiZ7KDGDhJvPZVxGZnUz8p5OIbZiQKjSlsTBmXjM24XwOLKnrjQLuSG7FLumR2LFsXxMdLXHuvggS9JxCuHPeXIK6IourVSDW719eHNqGJ7PKMSORyMGKeLlsAlWvArt2v6nt1a8eLiTyEkEx3Ecu7md1Bjh/4AE3BmLk6An5XTx6GdvjVv0MbCBIzw8Ow49MYnxlpO4euVXl/D5vEkwrzSpPEqRznYD4rXhNO9IJPlPruX32skB4H9M4l+aS3QkrZYQQWvPFONi/S2cWJjIUKGUQFCd/+/z8LGVw1kuMRk4fSogwk/CPTH5wBnEuSkx29cVG3JK8MqkICw4fIGEoLFIOZgFLzs5VoT3Py2gpjE0vEyy5K2GdPGrpEsovRDjN6xy3yxjvLtlStiwOopa7AR7dn3+qVRLuTlp9qMgN3Y+e5tHI68kBA0YagxI/jgL4MbpQL0ptxRz/F1uW+ejkI+9gn9ICBZiEkFBQUFBQUFBQcGHqeB4z3aOcxr/U7HgIgKAAgkACgAKAAoACiQAKAAoAPj9I27M9+SNJekMHVA3PovGzn3gbmdLnATRHkWQiFV3EiHh6Za7662d8Le3YQkVTUcPe4jtZi2DprMHer0BAzeVj4riRKa6rQtuNjLYDHnxaDSopUeLpm4taZP1XfnEnA0CnHfD3/AeKptfQH3nXrbffwA+uOMTfbMLU8CW/ucijs6bzICylZCe4Iy5lV2XKtDVp8OfU8JG1+6JTo4yCSSc6KFY1omKBnxQUDnozYC768PDx/FdeCvfQdWtdaht3zkEyHsYA7f+9xo7m19Ty9U041cnC/CLKB8cr6xnL1xsSw1jmbYdeeVQSHkEKm2xLNQTR65r4GVnjUkTHLCnqBKXG9pwcG4c1p27QtyAw9WmdkS52OPX0X5YejQPf0oKRrijHZZ/cRFTVc6YH+SGwoZ2vJNfhj0zovFpqQanbzRgQ2IIbnZ2o6K1C89E+cKUS8O6zCvIvdnC3tkIJjocKK6Gr4McSqkUbaTj56TnYlm4J3FVDn/9Ro3lYZ6E1/cuQIrg5fA6OzSt21HduunBJ5EEN0dsSTEmjaOcFfC0keOP2aVYE+uHRuIm/yKWa8WLWArzQq0M+0gj0kpqQLwUN9q6UUVclfZlS3cf0k0ZxlumF1AoDm/nl6NLq8d5TRPprCZW7iKX4lxNM34e6Y3ihlas/rqAbap9JrofvMNltThX3YSTi5JgTuVunmLU87OSm8STRDi6oN8Cy1vaUdLcPmIrdlOsQWnrT/FY2hX0GSqG1dOc3drJgXS/LAedzoAK0lj324x1XxML+Jwom6JyJBbQjb9dUmN1lLEXbSRillOmdKhMg71FVdg7MwYKGY8NWSWoaO9mdXRA8LGXD5NNy1eGebGE+Rx/N7b9maJ6XF2HRA9HZNY0sg24vgprAnAzZqXn4JPZcci62UTqlXCWy/CbjMt4kTTEluhCXzeqJOO5mFgSZ+Duy/1pyji9tAbbL15nRnBHPvohzLy7jRW+XTEVrSarWB8fBPO9XyaK0YOCVEvGSm87GU4vNmZTaXZ/msrJAiDdZj2fAED5DAY9tk0NZ/u4qXVuSgkZ1CCFVMzy21IygZD+w7klyUSeHnVk0qKNXxzsySzN207OZDR09SLB3QF5y1JZz7vburPkO00/0zbS+i6tDnFk6Eh0VzLdzFlgM708OejuwJFjPzGAnWTcvxfoLS5MrYaSlO8fPKXi/uuh1kmB40WDZ1ARafVAPrlphpUN4aMbAuhGg8HyRGQSG26lVmIxVAPK6T2sB/yXM7n8cN0GwzCwLUNd8YPLVXi/oILJvle7HfNt52NNFLRVkV7suA/SCpHIg5FBAFCIhQUABQAFAAUSABQAFAAUABToPuh/7/58N9v/C3gAAAAASUVORK5CYII=</mdui:Logo>
+					<mdui:InformationURL xml:lang="de">http://www.library.ethz.ch/de/</mdui:InformationURL>
+					<mdui:InformationURL xml:lang="en">http://www.library.ethz.ch/en/</mdui:InformationURL>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>libraries.ch</mdui:DomainHint>
+					<mdui:GeolocationHint>geo:47.37643,8.54772</mdui:GeolocationHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDWDCCAkCgAwIBAgIVAP9MGKsFmdRFRYW5axHOWey/sbR0MA0GCSqGSIb3DQEB
+CwUAMCYxJDAiBgNVBAMMG2xvZ2luLWlkcC10ZXN0LmxpYnJhcmllcy5jaDAeFw0x
+ODA5MjQxMTU4MDNaFw0yMTA5MjQxMTU4MDNaMCYxJDAiBgNVBAMMG2xvZ2luLWlk
+cC10ZXN0LmxpYnJhcmllcy5jaDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAI/fQY/ZH9wOGe4UmmcLZt/nPJt1ZaJfqDNWkwS6O8Ca5+HdYnGIJFZLTU/a
+hyWt+872j5tnKM/SBpsuLjm1FKOQGcH/RyovEHK/htTidsr8KElcwJJpLAf6P1qS
+jTsGzdwoodQWotOGE+2SW8Kbt71l9JZ+yjazFJzJ++17YEdn5oQnSQ2NgCA2jZxv
+8/fHzi2KsAg+adcXkR4O347OwSpUlTwYuTJ+Apsnx9fYM3bzGLsmr7hjugV2rV7S
+TF4C/lTqF4O11ImmkO+8V0vVtwJsfAgRS3AQQLn1G/ttPBadY34daygXRrGApFMl
+Go/bcSnXZfZ0B9Kp6ip44tGzmuMCAwEAAaN9MHswHQYDVR0OBBYEFJ8I8NPve7Ox
+KLwkgmUhuN9K3diwMFoGA1UdEQRTMFGCG2xvZ2luLWlkcC10ZXN0LmxpYnJhcmll
+cy5jaIYyaHR0cHM6Ly9sb2dpbi1pZHAtdGVzdC5saWJyYXJpZXMuY2gvaWRwL3No
+aWJib2xldGgwDQYJKoZIhvcNAQELBQADggEBAIFMRURnh7veEbyGAjA+nSqr9d3S
++Z2VTxd8ETwv30PusKZgwosM/zO9n/OY1r7rOEA4+MF6K8XXJFBZ1viiMl4PRbe+
+leJSIHNeabZVkGfsMwKbpgrR+49r4qTSultiVhrmoIcB1SxvM431eYyuTrV7/bjd
+quvdn2ZOi7oZOxx75VHzrm1X6Psxd4+63YU2atvPLH+n72W9wag939lRs6/IuaTq
+5XwKlOf3fgzlJdNDM1utnpnf+7Wx/jPAWOSMDRARsk2EcJYatFNKCCdgO9pTo+OX
+Pw1Zuf7Bd34xBf3BlRiN3GY0ZO0WmhPCOiyXB6g1WlyKGcoIPUsuGAg0wF0=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://login-idp-test.libraries.ch/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://login-idp-test.libraries.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://login-idp-test.libraries.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login-idp-test.libraries.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://login-idp-test.libraries.ch/idp/profile/SAML2/POST/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">libraries.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDWDCCAkCgAwIBAgIVAP9MGKsFmdRFRYW5axHOWey/sbR0MA0GCSqGSIb3DQEB
+CwUAMCYxJDAiBgNVBAMMG2xvZ2luLWlkcC10ZXN0LmxpYnJhcmllcy5jaDAeFw0x
+ODA5MjQxMTU4MDNaFw0yMTA5MjQxMTU4MDNaMCYxJDAiBgNVBAMMG2xvZ2luLWlk
+cC10ZXN0LmxpYnJhcmllcy5jaDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAI/fQY/ZH9wOGe4UmmcLZt/nPJt1ZaJfqDNWkwS6O8Ca5+HdYnGIJFZLTU/a
+hyWt+872j5tnKM/SBpsuLjm1FKOQGcH/RyovEHK/htTidsr8KElcwJJpLAf6P1qS
+jTsGzdwoodQWotOGE+2SW8Kbt71l9JZ+yjazFJzJ++17YEdn5oQnSQ2NgCA2jZxv
+8/fHzi2KsAg+adcXkR4O347OwSpUlTwYuTJ+Apsnx9fYM3bzGLsmr7hjugV2rV7S
+TF4C/lTqF4O11ImmkO+8V0vVtwJsfAgRS3AQQLn1G/ttPBadY34daygXRrGApFMl
+Go/bcSnXZfZ0B9Kp6ip44tGzmuMCAwEAAaN9MHswHQYDVR0OBBYEFJ8I8NPve7Ox
+KLwkgmUhuN9K3diwMFoGA1UdEQRTMFGCG2xvZ2luLWlkcC10ZXN0LmxpYnJhcmll
+cy5jaIYyaHR0cHM6Ly9sb2dpbi1pZHAtdGVzdC5saWJyYXJpZXMuY2gvaWRwL3No
+aWJib2xldGgwDQYJKoZIhvcNAQELBQADggEBAIFMRURnh7veEbyGAjA+nSqr9d3S
++Z2VTxd8ETwv30PusKZgwosM/zO9n/OY1r7rOEA4+MF6K8XXJFBZ1viiMl4PRbe+
+leJSIHNeabZVkGfsMwKbpgrR+49r4qTSultiVhrmoIcB1SxvM431eYyuTrV7/bjd
+quvdn2ZOi7oZOxx75VHzrm1X6Psxd4+63YU2atvPLH+n72W9wag939lRs6/IuaTq
+5XwKlOf3fgzlJdNDM1utnpnf+7Wx/jPAWOSMDRARsk2EcJYatFNKCCdgO9pTo+OX
+Pw1Zuf7Bd34xBf3BlRiN3GY0ZO0WmhPCOiyXB6g1WlyKGcoIPUsuGAg0wF0=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://login-idp-test.libraries.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://login-idp-test.libraries.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">libraries.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="de">libraries.ch Test</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="en">libraries.ch Test</OrganizationDisplayName>
+			<OrganizationURL xml:lang="de">http://www.libraries.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="en">http://www.libraries.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- PHLU - Pädagogische Hochschule Luzern (Test IdP) -->
+	<md:EntityDescriptor entityID="https://idp.phlu-lab.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor errorURL="http://hotline.hslu.ch" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">phlu.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="de">PHLU - Pädagogische Hochschule Luzern (Test IdP)</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="en">PHLU - University of Teacher Education Lucerne (Test IdP)</mdui:DisplayName>
+					<mdui:Description xml:lang="de">Pädagogische Hochschule Luzern (Test IdP)</mdui:Description>
+					<mdui:Description xml:lang="en">University of Teacher Education Lucerne (Test IdP)</mdui:Description>
+					<mdui:Logo height="16" width="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyZpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMDY3IDc5LjE1Nzc0NywgMjAxNS8wMy8zMC0yMzo0MDo0MiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTUgKFdpbmRvd3MpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOkJFQzJDNTZCNDBFNTExRTU5NTgwQUFBRTZGN0M0NzJCIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOkJFQzJDNTZDNDBFNTExRTU5NTgwQUFBRTZGN0M0NzJCIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6QkVDMkM1Njk0MEU1MTFFNTk1ODBBQUFFNkY3QzQ3MkIiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6QkVDMkM1NkE0MEU1MTFFNTk1ODBBQUFFNkY3QzQ3MkIiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz5d85u7AAAAx0lEQVR42mJ8sH/+48PLGIgGzL1zVjIysXx8eIlIDYz///8HUo8OLnp0aIn21qu41F311oYwmCCUnH2cnF0MCTZAwIuVvS9Orgcy5I/dB5I/hLleqotDpL4IckEYLMi6JcKLf0mIAt0G4f5lZYGrgwMmND5BtzFhCgH1cMjp4NLAglWUU04XSH799YhYDRA9fCyywAAn7CQ44NO0xfQPE/5QxwwDJoIxhaaHiZjYRdaDEtP4ATC9PTm2moX4hA205///fwABBgCa6T/37eZvowAAAABJRU5ErkJggg==</mdui:Logo>
+					<mdui:Logo height="33" width="80">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAAhCAYAAABObyzJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA4BpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMDY3IDc5LjE1Nzc0NywgMjAxNS8wMy8zMC0yMzo0MDo0MiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDpCMTdBOUZEMDMxMUExMUU1OUY3QTkyN0RCRUJCRjc2NiIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDo5RjZBMThGNjQwMzIxMUU1ODNGNjk3Qzc4REI1NDBGOSIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDo5RjZBMThGNTQwMzIxMUU1ODNGNjk3Qzc4REI1NDBGOSIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ0MgMjAxNSAoV2luZG93cykiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpjMGM5NGQ0MS1hZGZlLTQzNDItYjkwMi04NzUyYjQ2ZDI0NDkiIHN0UmVmOmRvY3VtZW50SUQ9ImFkb2JlOmRvY2lkOnBob3Rvc2hvcDpmNDk3NGYxZi0zNmFjLTExZTUtYWQxYS1lOTNmODYzZWE3YTIiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz4klLOvAAATb0lEQVR42uxaaXhUVbZdNacyzwMhAwkSQgYmEQQRDQhCawsoKqDSKmqDSCsITmhr2/pQFOjXrbZKOyCKMrUDIJOihjkQICSEEEJIQgYyz1VJquq+vfetqkx+Pgd+evjqS9177jn3nH32XmvtXWgcDkdpW3ubD6gpigIN/fPw8OBL2O02dHTY4HDY4WHygFano+sOWCyt9IwZRqMRnU1BW1s79bfDbPaEjp51zdneTvdtHTDTGL7P11arFZ6entBoNeiga41G657JTu/jZ7y8vKivwz2XQ3FAr9NDp9dTf5uslefnj9lsdo/nsW1tbfD29qZ5NaitrYXBoIdeb4DJZIRWq8Nlak0oKSlRklOSlISBA5TYftFKv7hYZcofJivnzuUrllYL9Q1SoqKilK3btirclj6xRAkPD1OmT5+qdG0NDY3KuOvGKpGRfZT33lvjvl9WVqoMHTZYiewbqaxf/4ncmzX7TiUiIlxZseJVZfOWTYqvr68SFR2ppKQmKUOGpiqhoSHK2o/WKus+XqdER0fJGqJj+spz8+fPU3JycpSBiQnKoKSBsubYfjHK+AlpSvq+dJl/0aJHlT59IpSk5EEKHYBy4OABJSgoUImJiVG2Offxs9uKFYqyeHHvT26udOvptJqyT+WIB5o9TbBa2lB4/gJaWu7Du+/8B0VFRWhqbCEvdIjJKysrUVFxCWfzz3Y7Cu7Pzc1F5aVqVFVXd/OG7JxT6GhzoKamRu4VFBSgvLwCJRdLEB0Tg8bGRvJmHaqqKun9HfLM5EmT8c67b6O4uAQmDwPCw8LI0xzinU1NTTiTmyfPeXqZ0E6ef6GwCFlZWSguKkFzSwvKysrl8/QzT+LVV19DYHAg8vPOybt+URs9GhQuQGYmaOPAlCnq/fBw8UAth0dgkL/cO5pxDDt37iS3B06fPo28vDPoH99fwqC8rBT19fWw2WzybGBgYLf38DPBwcHqpig0XY3nDwkJle+uMAsICJC/PN+0qdNQTQbfunU7PM3quKVLH0dwSDAZolmuhw4dir17f0BGRgZeW/E67LQGnV4jfVlZOdi1aw8YAaoqq1FWXoaoqL7S5+3jiZUrV6G5uQmbNm6We1qt9pcbMC2t85q/88dftZnWtXm9Xoft27dh73ff0klD8M2PHrIRDnp6eeDxJYvJW/rKM07I+82NccpgMCAoKAhfbf2KsKoBPr5eeGzRYrdXcysuLsakyRNx1ciR2LJlC8IjIuRgPMwmrFv3ETZs3AByTgxI6I8I6quvb5BxvCe73YFFixchNSUVQ4akorDwPC5n07u8hBe+ZMkT7o4FCx7BkMFDUFdXJxsxmcxyehrNz5hUr+92bbfb5a/JZJK/bLSuBiopKcaqlSvl+0MPPkThGt5rznYytpbcrF0IRyNzeHqa8fxfX5B+P38fbNywWYiq2gkh49PGY/+BAwRFa7Bs2bP48MO1OHTo4GU1oNa1kZYWC6ZOuwVLKHwI2PHkE0+htbVV2NLS2obly1+hsD6DG290YsBPGLJrmPDhaJwP83wCHIRh0ud87pVXl1OfFaFhIZg/f0EXYlfdnGEk89gJlJaWYu7cufKXvZfnnTZtKkJCg2iNVuTn5zvhRB0+dep0zJs3X77fe+8cpKYOxl2z776sBiSXLmykEOWVKrt37+pGQGfPnlV8/bylb/vX2+Xen+c9JNejrh7R7dm6ugYlvn8/6Usm9ps46QYlLe16JTMzU7lm7Gi5P5gYdtbsmYrrfRs2fKYQqLN2UnR6rRLRJ4yeHaMMGzZU2bFjh7Jy1evyXDjdvz5tnDJ27Fhl9epVyuHDhxQniChHjhxRbr9jhnyPi4+VtSx4ZL5cr1q1UiEJoxiMOrlet26t8qubi427t0YtayjWbtxqa+t6eVKHkzRc7NXaapG/tg57j6NQRCNyy84+jV07d+Pbb/fCYDS4Me3k8Sx88vF6tLZYxSNmzLgdjz66UExhJjxjuNiXvp8I7zh5ew6FqJeMqyMdt/fb75Geno6du3dS+Hbqz4AAf9xz9xz5fr7gAvbs2UP3At3YyYT154fmyfXCvzxCzFx2WR1QQyHamJ19yoc3n5CQ4H45tw6CqPziS2iuLsHApMHwNRtQeOECLhJmBQUFY9CgQd1wLicnWySFVqcVcetwKEhJSRFhfuzYUZEZjF0JCQMxYsQIGUfaDWYR6Z1hz0wfFxcv0MKg78JMm81O4RqCsNBQUQk8f2pqqnt+q7WNCCac2NxM4XwOpPvkY7VYkXXqJBrICRjXQ0JCLpuQ1rAb0hefH+u1VhXCcupLBKT9BS0Fh3Hx5DdImP40fm+dBvxJUdRSU4aML/4t3xtqynEpazfJBfvvZusawpTnNtbmHfSx1BTDZm2FOSgSYUNu7PbQpRM7YPQORED/qzplRWMVas4eREdLPRz2DvhEDkRQwpheL6g8sQtakkDBiWN79ZUe3IiGCycZbBE86FqEJKWRINYK+xZ99z6aSs/CIyAM0dfeA6NPkHtcY0k2yo58DntbK7zC4tB3zEzoPbxQeeobmHyC4Rc7WJ4rP/olavIOQmf0QMSIqfB33m+5dB4X93+GjtZ6BMRfiT6jbkXduQzJxwP6q9DS1liNWtpfaOoN0FIOXZW9F20NlVBor/YOUgxDJsErJLZJ99yyZ57KfHOuqeZMOuztFhTt/QD1FzIRkjyeBhrpZQX4/rlr0ViUhdi0+92bqMndh+NvzyOPtKH1UiHObVuNlorzCBt8g2oEXmhlIfa/OBFVOd8heuxs2YiqThw4ueZhFOx4Aya/UFhry2gDRxA56jYho4zVM1F6aDNM/uGoIqOU7FuPsKGTYTD7klG+wpGVd8gcWp2RDncnfPomwis0FkdWz6I9tCI0ZTzy/rsceZ8vh4dvKBoKj8s6gxOvRf35Yzi4/GZ0WBpEizVdPI3wYTch5+MnaY8nxNAScYXHcPRfcxAzbo6Q6eHXZ6C1ugjtzbWoozkC4q4kZ+vbrlc3ZEfs+Afoc7+cxIH/uQl9rppOE0+hxX+C4KTroNjaUXF8O8KHqjrQbuuAZ2gMhs9/TwxdkbkNGf+YTRudROP+IM9UHN2KgAGj5NQqjn+NqGtmur2y9NAWjH7yCwRcMVKdj05Vq9PT/U2oPv09xr7wPXl1AnlZC75ZOgwlP3yMAVOX4symF8nQt2Lw/f/sJLB2VRkYvQPI6GEqI+98AwNvexb9JjyoEpBF1Z65m1+ieRMx+ult3RSECH2/UPcdk28weXOQiHYHZWNagweGPvhveAZH9xbSfBJ6s8ojXmHxYhCdQc0aKk/uQcItSxE08BqUZ3zZGftaiMs7bKoEYqMFxA2XA3A1Nnj85AUIS52IsozP3fdrydsC4oe7jSei2qB6Z13+EQQmXC3Gk/smLwqjibDUXiRPLSVjWdFv0rxum9AZzc416eiwVIz26ZskRmePk+yI9tdhaYSlqogi6b6eSEbv8YS1oUo8suliLuoLT4rRGF54s2yP+vOZ0tdcftbNBXoebCTcKD28BRaSK6WHN8M3Kkm8rqHopMiRkOQ0OZ1jb94PG+GO3uTpTkUUu63zNGgjtja1ANBYnC0LZo/1jUpBcfrHhCGXaJ4wwp4GaPSqNLmUtQdnNv6N8CkVyXe9KhvRm7y6G4g2wqFpqSklQ3gLzknxg0KsnbAq7saHJVrYW1zeOGTuGwQT87H/pSkISrwGQ+77XxjIQ/nANTp9LzzmdVUc24qsDxdLKmNrbSTs9pJD4cjQEY6f/XIF7ZqM6eGJEQs/Ii8NdRYTuFDaXEOgnYuIK2/GVY+tl4EVmdvpfi3ObV0loMsgyh7SowzTGQhkTJ1BrajUnNknYwu2/QPFe98X7KjJO6AaWmdwF1C9gqMQSJ7IRMWgzgZ0OGzdJTrNq9HoYPDyg6OjTcKdWxgBeSN5RF1BhtuTXOmfd3g8xizbiZGLN6KVsDhr7eMEQzboPX1+NA1tqy+nKBuD4fP+Ix+GC7u1WTyN18OElUiQMHLRp9Jv9A5yhbAihokeezeGzVuDhGlP0UIDwOWN2vzD8IroTy6bTwzdLJ5aSVLGtVg2gsHTTwXd4lNEPidkEdyq8/YTXsSgica2N1XDTNjBZCLhRYzNocDG8O6TgJR7VpBn+Umo8Ji6gmNuT5LDOHtAIoDhhb2XGZFb1DWzEDxwNHlVR9f0qZthmN3737RIoIWJx+gdTMS0t1cWZadszOjlD4/APsT8EXIA4DDlAyFB7yDj+xNjewRGMnmIg6khTA8wC7IRu7ayI1+ILLhhZTY8Q2LUQujX/0LOp8uQOONZeVlTWR5O0clyWJQf2yaUz15RV3CUCOQrjHsxHb7RKWpa9cM6HH93PgnxZ4igpiJ/60rsf3kKosfdLXKhjSKAF8rjcze+QEz5R0QRczP5tJFkirz6Ngk9JpDsdUvlUPiatemAPy6Rd1gII/0Yk8lQR/85B96Eo3oPH5zf9RZCB08kx/BH39G34/g78whCjMTc6mElz14uLM3j3R5J87fWlIgHsqpop/Vlvf+oHDC/O+7G+fCLGQzd88//9SliWBPrH0+SAm6JTUDpF50s2OJqniHRwsb8LHuj6totArYsUxJnPOfGPy86Qd6sq5kpVBXyONZtfCChqRPQXJon8kVHm0yY+gS9L8lJGhPQUn5ODMtsmHrvasFlbiEp40WX1RBTW+sq6ADuIZ14txr6RDD+ccPIe/rDWn+JYGS/aL7IkbdK+LHB/WJS4R1xBY1PR3PFOSG+4OTrWFZIZPjSnlWndAj2sgdrDWaud9Ath+yf8TiQNDF5avtPpnK/t9+Yyv3efmZBleOfAbazjumQe+hyj/WXpeaiW/f1bIwfDPBdmdPFiOo77L3yaGtdubBzz8aExe9yPc9zdR+rONen4EfX3+VdEnY9WN31jMPeTkRmlU9XOfaLSvrMYMfeuFewLmrsLDVHpWyg7NB/cSVpHS4zXfhmDQrpw/rMbm0hVnuU8s87nXlpDrI+WEQsZhG1P/DWZwU3Mt+6H0mzXnZjV+6G58X4yXe9IsY5tXYxLGRANlYEifBBd74oz+V/+RouHtgguMqab+SiDfJ+1qgpc15XU0RKGbM+eEzm4jTuyMo7EXP9nxA+/CZ1ji9WoL2lTvoLiUCY1IY//H7nL4i055xPniLVcFIEMpNF/8kLJRP7Fb+JOERLBcSP6FIoqEZj6WkRkAzkLC6TZ76EkNTxogdPvPuwJOw+fQZS3jpLSCH5ruWkpS5J0t/WUEFEcopAvVOKtFZdEFHOjZmbk/WhD7xFYF+Bjha1kFuS/gnObP67kAbnmg1ERtyay/LJ2J2FULvNKn2szeQQKXvo6smtZGxro6oqLHWlpBbO9nQ/KTIwYTDRseD3i0r+tT8qaUTLmfyC3TeNviFuoXjx4CaEJF2PuMnqbxWJtz8vCXzNmQO0AfI6YuErF66lOfzd4+vOHRXJwAzadU6HUwCzB/rFDhHvdHmoKnXWCqvGXPcnuXYxIoebybezCMqZCB+US4txpUjrTAVlUx7eMNjUd3HU8Fp6N4WibjLCSN78xl/lNGS8EKl41DnzxuaKAng4E+uO5joSu1d0G+QV1k9On0tgnFwbzH7dgdXoIfnpadJzqiin/Df/kFRDuMVPWYgTaxZIhhA7YS7pwmkq9tFhdDWoq3n4h6OCMpWsDx+juSjNIo+RFMuZr//yIh7JqqAoFO5+h0T5dwRLTbji5scFDn4diVBocbhyuYg//F1xVig0kqpperxf4/5/L1JV6PEjscb5i5pGZ5QknrFMEn0n0LOYHfX4Juljwcu4x7gkBQWN9kd8RZGSkt7kTamYr4jgXjbpMk6j+///7wsTC++Vo4Szi197GHpeHhdH+93woLvcxLW48zveVBdDi+3JlBbCrSB6IYd+e1OVMJ2my28anBZxvpp46zIR0IJ7bYvR3iXbYaLhT8m+T5Gz/mlEjrmD5gvolRGpeWqFhLOLaDhL2P/3ye4UjtM+V0VGSILYlcnOpSg0Wn3PExFMTbjlCcmKfrOM4XBk4nAvmAzKwMotNDkNFRlfoDo3XaTMxQOfob4wUwoA/qTirbTh3E1/EwZuodDnkg//jyubzNlpDD4ElwdyTtxaXSwb5ySeMwuuvfGchXveIXY8Lmqf39neVEP9Jkr1On8x5IPgMGbmV8tZHihO/4hkVCPBSgkqKK30Cu3nlEB2WUczpZ2sGPi9aulLK+zMeX5DUdaPHtzP/Z8JPgzIXU+Qv3NxksGbc9DKU3tw/O0HaVFx8kLOPV1l8+SZL5MBX1DzWVpE7IQHEEmYxpVgdDl5A9cbndfF36+VUpnRK5C0YBkG3f4CvdMTMePvQ/WZdCnMmimsmKRGLt5EIRYhBu1aMOBU0lX7S6TxnKceem26HCQXHRhnJYWkeRhbWUlwPhs44GqkkLzxjx6MajpIrrSzUftPeQQxab9YxvhQKucopVP24Vqeqw7HHskLNhC7ubCFS0ace3Ke2RNsWysvyOkafQLJi0a5w4zZj0tXQkYt9aoh6R5viD2VN8u/UzAGdW2cw7KO86dknSFABDrBBNfzXMKa+wWvndglpbbzR+UgQgaNc5fZeB/smQqFO1fedZTXctWa631cu3Q4RTo7TFcl8XNTuf8TYADVLm9s0FZGJwAAAABJRU5ErkJggg==</mdui:Logo>
+					<mdui:InformationURL xml:lang="en">http://www.phlu.ch/ph-lucerne/</mdui:InformationURL>
+					<mdui:InformationURL xml:lang="de">http://www.phlu.ch</mdui:InformationURL>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:IPHint>147.88.204.221</mdui:IPHint>
+					<mdui:DomainHint>phlu.ch</mdui:DomainHint>
+					<mdui:GeolocationHint>geo:47.051064,8.302218</mdui:GeolocationHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDKDCCAhCgAwIBAgIVAO4s+6qsfWs0gUYuqUmGnhUIv14MMA0GCSqGSIb3DQEB
+CwUAMBoxGDAWBgNVBAMMD2lkcC5waGx1LWxhYi5jaDAeFw0xODA3MDkxNTAxMjda
+Fw0yMTA3MDkxNTAxMjdaMBoxGDAWBgNVBAMMD2lkcC5waGx1LWxhYi5jaDCCASIw
+DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIx55636kYwoqpYzhhdjCbqB8zMm
+73I+i7TWnhsTwB44+x2qS5pv9nBIrJUsy3GmQY5HXuqIp+DSomv90Ya2KDmkKvs+
+bEDZipidyeoeoODcUNLaSzvxyv5kKwWlOxERtgqNbqIErqcRUqgbMrW8VdPkuj4d
+LxKJwFGwFsG5FjjVxkHmdPz4GDeWg6w62ik5UXrPv/K6iAUzhBOjpoFCABt/dWKb
+2utHgVhOv1m34vUHcTj2ZUpHhpUwbvrZyv4vAzEzeTa7+c4WYX0WGxatcaPoWBZM
+012VOCHIEeuvCJD27+p9/qks/k3mXjz6aNP9R1cnGPyK/YtFjuDLv6zzPe8CAwEA
+AaNlMGMwHQYDVR0OBBYEFHkNaMgl6r53qr6GY10mEaJ2FizeMEIGA1UdEQQ7MDmC
+D2lkcC5waGx1LWxhYi5jaIYmaHR0cHM6Ly9pZHAucGhsdS1sYWIuY2gvaWRwL3No
+aWJib2xldGgwDQYJKoZIhvcNAQELBQADggEBACxo/PraPPZG7JBgkwinG/vZB43H
+38yEXSf5hgzC65l7/CDi8ImSPWQwJb0cvEVf636S9lhpo/ntwh5Z+VvFXzJoHViI
+QCA4RZ3dPYB+sTPvxg+1myq5oD8mTHw60VhNQ38dERd6STYOHxF4YX9DcOmv3y14
+akP4wtRzY9rGg5M9fOLBAqa+oBkLLdlDo8sMRsvhZ+weDaBI8IfcT1wslfocPayh
+Dbll2t5PCZgjjQDMvv7V8G4cgTrwRienm32FSs+hb8WsdPscza9gi17EYlIwK8ok
+vmCeOyaeLrfAWjuUhp+l56XmsmAt2QwMhDtF7ad/WhdWvYx8fsU0da7sr44=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://idp.phlu-lab.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.phlu-lab.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.phlu-lab.ch/idp/profile/SAML2/POST/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">phlu.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDKDCCAhCgAwIBAgIVAO4s+6qsfWs0gUYuqUmGnhUIv14MMA0GCSqGSIb3DQEB
+CwUAMBoxGDAWBgNVBAMMD2lkcC5waGx1LWxhYi5jaDAeFw0xODA3MDkxNTAxMjda
+Fw0yMTA3MDkxNTAxMjdaMBoxGDAWBgNVBAMMD2lkcC5waGx1LWxhYi5jaDCCASIw
+DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIx55636kYwoqpYzhhdjCbqB8zMm
+73I+i7TWnhsTwB44+x2qS5pv9nBIrJUsy3GmQY5HXuqIp+DSomv90Ya2KDmkKvs+
+bEDZipidyeoeoODcUNLaSzvxyv5kKwWlOxERtgqNbqIErqcRUqgbMrW8VdPkuj4d
+LxKJwFGwFsG5FjjVxkHmdPz4GDeWg6w62ik5UXrPv/K6iAUzhBOjpoFCABt/dWKb
+2utHgVhOv1m34vUHcTj2ZUpHhpUwbvrZyv4vAzEzeTa7+c4WYX0WGxatcaPoWBZM
+012VOCHIEeuvCJD27+p9/qks/k3mXjz6aNP9R1cnGPyK/YtFjuDLv6zzPe8CAwEA
+AaNlMGMwHQYDVR0OBBYEFHkNaMgl6r53qr6GY10mEaJ2FizeMEIGA1UdEQQ7MDmC
+D2lkcC5waGx1LWxhYi5jaIYmaHR0cHM6Ly9pZHAucGhsdS1sYWIuY2gvaWRwL3No
+aWJib2xldGgwDQYJKoZIhvcNAQELBQADggEBACxo/PraPPZG7JBgkwinG/vZB43H
+38yEXSf5hgzC65l7/CDi8ImSPWQwJb0cvEVf636S9lhpo/ntwh5Z+VvFXzJoHViI
+QCA4RZ3dPYB+sTPvxg+1myq5oD8mTHw60VhNQ38dERd6STYOHxF4YX9DcOmv3y14
+akP4wtRzY9rGg5M9fOLBAqa+oBkLLdlDo8sMRsvhZ+weDaBI8IfcT1wslfocPayh
+Dbll2t5PCZgjjQDMvv7V8G4cgTrwRienm32FSs+hb8WsdPscza9gi17EYlIwK8ok
+vmCeOyaeLrfAWjuUhp+l56XmsmAt2QwMhDtF7ad/WhdWvYx8fsU0da7sr44=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://idp.phlu-lab.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp.phlu-lab.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">phlu.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="de">PHLU - Pädagogische Hochschule Luzern (Test IdP)</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="en">PHLU - University of Teacher Education Lucerne (Test IdP)</OrganizationDisplayName>
+			<OrganizationURL xml:lang="de">http://www.phlu.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="en">http://www.phlu.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- PSI - Paul Scherrer Institut -->
+	<md:EntityDescriptor entityID="https://aaitest-logon.psi.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor errorURL="http://www.psi.ch/computing/contact" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">psi.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="de">PSI - Paul Scherrer Institut</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="en">PSI - Paul Scherrer Institut</mdui:DisplayName>
+					<mdui:Description xml:lang="de">Das PSI ist das grösste Forschungszentrum für Natur- und Ingenieurwissenschaften in der Schweiz.</mdui:Description>
+					<mdui:Description xml:lang="en">The PSI is the largest research centre for natural and engineering sciences within Switzerland.</mdui:Description>
+					<mdui:Logo height="16" width="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3gMHBwccYJhJmwAAAOBJREFUOMvtkjFuwkAQRd9KPoBThwaqnVMgmVwAemQKyBXi2JeJRR+KgAuEkbgE5gDQEskXmBSE1RorTVJF4lfz/8z/O9IO/HsYAFXVX5mNMcGVzPM5VXVwTRHb4L4mYhnH44uo33h9SdXHLfc1vxcAlNsdAKfjkc2mZDgaulcX7wvqum6tX253DKI+gS8+djrEk7gx6IelSdYKagRU+z3Lj8Lx/C139W1wI2AQ9SnXa87nT8KHkNnzlDTJfjRdPQCBMcaoqopYVsuCbq97GXiKWiuLWNIkQ8S6b/zzHXAHX88Pfvx23KcVAAAAAElFTkSuQmCC</mdui:Logo>
+					<mdui:Logo height="28" width="80">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAAcCAIAAAB56a/tAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAB3RJTUUH3gMHBwwbHQgF8wAABpRJREFUWMPNWG1IU28UP/fubm5OLd2yzdI1GXO+1NJJWWmlhWCRhAVZMCtDTfzSl15gEEFBLx/sW4SQH2T0MqGCQhRqEMHSMsiXrH8Ww0yd/Z0657Z7t937/D88tP/w395M/fv7MC7nOec85+w5L89zAP2CVCo9fvw4Qsjn89XX12NiU1OT0+l88OABQujRo0f9/f0oCE1NTbW1tfi7sbGxoaEBIdTV1WW328+dO4cQ6u7u3rx5c29vL0KorKxsx44dWP/BgwdPnjzJsuzU1FRGRsbDhw8RQnV1dfn5+TMzMwH9DofDYDAghC5fvmw0Go8cOYIQ6u3t3bt37/fv371er06na2xsZFnWYDDMzc15PJ6tW7eePn0aIdTe3u7z+a5evYoQMhgMGo3m06dPCCEKfkEul5vNZgBgWfbly5eY6HK5EEJerxcAGIZhWRaC8OzZs2/fvmGRjx8/vnr1CgB8Pp/b7Z6fnwcAt9ut1+t1Oh0AxMXFzc7O2u32pKSkwsLCmZkZlmX9fr9Wqz127BjWr9VqBwcHi4uLsX6EkNvtBgCO4x4/fuxyuQBgeHj47t276enpALBnz57a2lqSJN1uN8dxQqHwxIkT58+fBwBss8fjAYBr167ZbDaNRgMAZMD60dHRlpYWAPjw4cPu3bvfvn0LkdDd3V1dXQ0Adrs9JSUFEzmOM5lMNE0DAEVRnZ2dDocDAMbHxzUajUQiAQCz2UzTNJ/PJ0lyaGjo8+fPAOD3+wcGBgLeBoNhmJycHL/fDwBVVVVnz54dGRmBReFfhzds2FBZWQkAbW1t7969e/HiBf6PZ2dneTwe5nE6nRzHBUTEYnFWVhYApKamWq1Wp9MJAARB1NTUCIVC7ENxcbFYLAYAiUTS09ODBcvLy8fGxjiOQwhlZmaqVCoA4PF4DMNgrwJACOGoUalUeGuSJC9duvTkyRO8ihnwb/AHQRAOh+O/dN6VK1fw1/z8/K5duwBgYGDg/v37fX1927ZtUygULS0tp06dio+P93q9z58/LygoEIlEgZAGgO3btwOASqXq6OjYuXOn3++XSqUcx+Xm5gKAxWLJzMyUSCQMw1RVVfH5/OTkZJfLVVpamp6ezuPxBgcHhUKhUqmkaVqv11ut1k2bNgWsZFlWo9EwDKPT6eLj4wsLCycnJ41G44ULFyiKomlarVYnJCQwDKNWq/l8vtfrVSqV+Axu3rxZXV0tl8sBgKbpvLw8ACACri8rEEIEQfwJw1JhhRxePaAWJ9bX13fv3r0FRTsMtFptfX290Wi0WCxRniRJkgcOHKioqLh169aCEoUQKioqqqmpWaET/vLlS05OztGjRwPJHGEPgjCbzT6fj8fj7du3L8pdWJZtb28XiUQKhSI/Pz/YTpIkOzo6Dh06hNtKzNkVK/bv33/nzp2YRHCXGhsbi0mqv79fJpP9dslqtRIEMT09Havx5CKiwul0JiUlxSQSFxcX+I0eaWlpoYIoISEBt73F9+EY0mCx5TTW9Am02SW0hFzNFZUkyeWq0nNzTo+HBoh8AgKBwOfzLSDSNI0vz8FsEcPebreHOUCEUHNzM76xhWL4+fNvluWiCUqRSJiUlAgAFMdx3d29+F4eDfh8vsvlWRBKbW1tDQ0NwZTy8vKurq7wqjZu3IiLWfh+FmZ1aOivNWvWRGm5WCwuKiqkhoe/Ru9tKOj1+srKyuCMEggEEaVGRkbCn/Dt27fx7XVJ4HK5hoe/Uj9+TPy5LpFIFGVPDkZqamp4hosXL5pMpiVM4B8/Jsjg189qw5LbxnHcilbplXkerIq2hAcXEUvU6n08LEBPT8+NGzcoKqS2N2/eZGQoSkpKCgoKwlQphULR3Ny8vA5LpSlTU9N/qGV0dLSzs7Oy8nAohjNn6sbHJ96/f4uHG6Egk8mW1VupNIXKzs56/frNnyenTCY/c6YuVJaKRKKSkh02m239+vX/YzxnZ2dRQqGwtLRkYmLS6ZxHKHJVFAgEAgH/v+1TIBCkpclIkvdbKaEwDk+tltYBmSw1OTk5ivMgExMT5PL1FM46iqLS0zdEv018vOi3xLy8nBWu+dnZWXgMurxVmuO4BaFLkmTEl80i2hJBEKFEMH0RjXoxVbqiosJoNJaVleEA8fv9ra2tubm54f1RKpVPnz49fPhwlI9EjuOuX79utVotFotarV6wajKZEhMTA8Pw5Z14IIRKS0uDlWzZsiWiiM1mW7t2bUy2rVu3rrW1NdQAINb5CcY/TjaN7pV996gAAAAASUVORK5CYII=</mdui:Logo>
+					<mdui:InformationURL xml:lang="en">http://www.psi.ch/</mdui:InformationURL>
+					<mdui:InformationURL xml:lang="de">http://www.psi.ch/</mdui:InformationURL>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:IPHint>129.129.0.0/16</mdui:IPHint>
+					<mdui:DomainHint>psi.ch</mdui:DomainHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDMDCCAhigAwIBAgIJAOx2a1HjaIFpMA0GCSqGSIb3DQEBBQUAMB8xHTAbBgNV
+BAMTFGFhaXRlc3QtbG9nb24ucHNpLmNoMB4XDTE3MDEyMDEyMjk1NVoXDTIwMDEy
+MDEyMjk1NVowHzEdMBsGA1UEAxMUYWFpdGVzdC1sb2dvbi5wc2kuY2gwggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCQl0ge4rPz6hsbyeeK1O25CA3aw57C
+oUw2JMLEW4WUTFHIr/CAJBIA39Xf72VDPVNamKHy+aYxm8muoQROdb/3a44eSoH9
+90qtU/vc2R9ZAOPS3vZ4Imr6hnVU9oX6YC8VZeXUOtQxctmKeG20t/gJj2JA15c5
+nNKtKkiTNeFfx8NvDSzMNrgWsBF+jSioLiESm7xubSLxP8Va1xEuIh4ddwkxbF0+
+N2UoKgtVRdloZA+fSt+6778raoI+LI9LUwgBjmCLfoVr83Zd6qDy6Z+G3Mmtpr8N
+1wMKpnPwQ4nrUuAINHVVluGUV6I4YBC+FD9wutTsKxnFsoEj9mW6sfr7AgMBAAGj
+bzBtMEwGA1UdEQRFMEOCFGFhaXRlc3QtbG9nb24ucHNpLmNohitodHRwczovL2Fh
+aXRlc3QtbG9nb24ucHNpLmNoL2lkcC9zaGliYm9sZXRoMB0GA1UdDgQWBBSTQDo8
+/e2xPytVx9KndXKGGKjkKDANBgkqhkiG9w0BAQUFAAOCAQEAgQFdOKt2lrM2ikjH
+p8Kvn7t1GPiGS540iKI8UTgTcaugZnZWmWS2rkV1aFlIW4KJK7vqCg77ktW0ns8L
+PR0BgZDTYHA/L9rCVYJJBqyuSRdPr6iIiVNYv+UiVUDHiNUh2p2J9Bz+p621lXuH
++pb2b9429x6EPSLGiXzpGB5GSlCVbUDIUi3Re6qvI5moBmi2rftflhcAY4zaTWdR
+AJuCzdRqcfy/IVvlE94E9RaR+kCBF+At2ePBQp9NIZvW2AIZAu/WO+nStU74hbx2
++zrEw1hgizzaLvlHRFn22uqvGlzx4J5AaVmZPkqnf0bqat+Ji6g0RJa6isZpZCtn
+CzdA8Q==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aaitest-logon.psi.ch:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aaitest-logon.psi.ch:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aaitest-logon.psi.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aaitest-logon.psi.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aaitest-logon.psi.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aaitest-logon.psi.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">psi.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDMDCCAhigAwIBAgIJAOx2a1HjaIFpMA0GCSqGSIb3DQEBBQUAMB8xHTAbBgNV
+BAMTFGFhaXRlc3QtbG9nb24ucHNpLmNoMB4XDTE3MDEyMDEyMjk1NVoXDTIwMDEy
+MDEyMjk1NVowHzEdMBsGA1UEAxMUYWFpdGVzdC1sb2dvbi5wc2kuY2gwggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCQl0ge4rPz6hsbyeeK1O25CA3aw57C
+oUw2JMLEW4WUTFHIr/CAJBIA39Xf72VDPVNamKHy+aYxm8muoQROdb/3a44eSoH9
+90qtU/vc2R9ZAOPS3vZ4Imr6hnVU9oX6YC8VZeXUOtQxctmKeG20t/gJj2JA15c5
+nNKtKkiTNeFfx8NvDSzMNrgWsBF+jSioLiESm7xubSLxP8Va1xEuIh4ddwkxbF0+
+N2UoKgtVRdloZA+fSt+6778raoI+LI9LUwgBjmCLfoVr83Zd6qDy6Z+G3Mmtpr8N
+1wMKpnPwQ4nrUuAINHVVluGUV6I4YBC+FD9wutTsKxnFsoEj9mW6sfr7AgMBAAGj
+bzBtMEwGA1UdEQRFMEOCFGFhaXRlc3QtbG9nb24ucHNpLmNohitodHRwczovL2Fh
+aXRlc3QtbG9nb24ucHNpLmNoL2lkcC9zaGliYm9sZXRoMB0GA1UdDgQWBBSTQDo8
+/e2xPytVx9KndXKGGKjkKDANBgkqhkiG9w0BAQUFAAOCAQEAgQFdOKt2lrM2ikjH
+p8Kvn7t1GPiGS540iKI8UTgTcaugZnZWmWS2rkV1aFlIW4KJK7vqCg77ktW0ns8L
+PR0BgZDTYHA/L9rCVYJJBqyuSRdPr6iIiVNYv+UiVUDHiNUh2p2J9Bz+p621lXuH
++pb2b9429x6EPSLGiXzpGB5GSlCVbUDIUi3Re6qvI5moBmi2rftflhcAY4zaTWdR
+AJuCzdRqcfy/IVvlE94E9RaR+kCBF+At2ePBQp9NIZvW2AIZAu/WO+nStU74hbx2
++zrEw1hgizzaLvlHRFn22uqvGlzx4J5AaVmZPkqnf0bqat+Ji6g0RJa6isZpZCtn
+CzdA8Q==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aaitest-logon.psi.ch:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aaitest-logon.psi.ch:8443/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">psi.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="de">PSI - Paul Scherrer Institut</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="en">PSI - Paul Scherrer Institut</OrganizationDisplayName>
+			<OrganizationURL xml:lang="de">http://www.psi.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="en">http://www.psi.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- Université de Neuchâtel - test IdP -->
+	<md:EntityDescriptor entityID="https://test-idp.unine.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">test-idp.unine.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">Université de Neuchâtel - test IdP</mdui:DisplayName>
+					<mdui:Description xml:lang="en">Université de Neuchâtel - test IdP - test-idp.unine.ch</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>test-idp.unine.ch</mdui:DomainHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDMDCCAhigAwIBAgIVANdsWLdgOapLbTaY8XTbsHEBqEMEMA0GCSqGSIb3DQEB
+CwUAMBwxGjAYBgNVBAMMEXRlc3QtaWRwLnVuaW5lLmNoMB4XDTE5MDIwNDA3NDcz
+M1oXDTIyMDIwNDA3NDczM1owHDEaMBgGA1UEAwwRdGVzdC1pZHAudW5pbmUuY2gw
+ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCIqFkd93XULEGBbcT6Ay9u
+L274lRPc7E1Yj4B8hfWT2M9TnUnQ4ch9IyIUpBJNWd7Gnkje3U61WHI1u2ww5UVI
+n18roalTpMfuMfE3VZZoEgwvieTLrDZU44eBI7rOy6VbayQfP+E+pMWZ1tzCTR8s
+MAvZijVD/79m6H0SdcwiIfiOUt2mgVpYGYcA4NqdPpKmQJdPHRf4XwIVV+wd+dDs
+gUcp0Nq+fzo47xGm1MGvQx05zO3nfeuvYRbAljF4r/upwkFYmkj1bEJ50MgbZdS8
+vgTUe8pvcjOpL6P+8f9q4rBctvnzQ1DZqwOj+9IbydekHhJ7oJXZYbnolh+ZKlPB
+AgMBAAGjaTBnMB0GA1UdDgQWBBR8hkA4Jl0bRUPG8H3JATeEXl6J3DBGBgNVHREE
+PzA9ghF0ZXN0LWlkcC51bmluZS5jaIYoaHR0cHM6Ly90ZXN0LWlkcC51bmluZS5j
+aC9pZHAvc2hpYmJvbGV0aDANBgkqhkiG9w0BAQsFAAOCAQEAbtdMBv5hd4K+EuAz
+BNxwb++FiV9fRP7+wsCUtZAmvkdX9TkpxGru3jrVS2tN9kd45PiPT/qCGaMx3LgY
+XuhgwI49VYL7es6Soc3aQAY90zwqYhKFT+OJp7wsrKRZdSz5g2VPCJKiMpLY7g8f
+mtYCDIMG2A2gkQl2Zqekm8CH5qgEz3XBCZQ19h5wQYrJk6VCAJY78irhFUPWsxIR
+m/2zNvNzNBGi9p84KZ+Fn9S9GaFIx2wm9mWFCGQ4ClGXyXL9jnNADyYlrjuN30uA
+8lmloJmoOlIepR1/G4fPcVOndbEGUX5QbY+MMlK9KXR34evTNSYvP6XjwxWpXw2d
+1c2eAQ==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://test-idp.unine.ch/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://test-idp.unine.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://test-idp.unine.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test-idp.unine.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test-idp.unine.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://test-idp.unine.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">test-idp.unine.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDMDCCAhigAwIBAgIVANdsWLdgOapLbTaY8XTbsHEBqEMEMA0GCSqGSIb3DQEB
+CwUAMBwxGjAYBgNVBAMMEXRlc3QtaWRwLnVuaW5lLmNoMB4XDTE5MDIwNDA3NDcz
+M1oXDTIyMDIwNDA3NDczM1owHDEaMBgGA1UEAwwRdGVzdC1pZHAudW5pbmUuY2gw
+ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCIqFkd93XULEGBbcT6Ay9u
+L274lRPc7E1Yj4B8hfWT2M9TnUnQ4ch9IyIUpBJNWd7Gnkje3U61WHI1u2ww5UVI
+n18roalTpMfuMfE3VZZoEgwvieTLrDZU44eBI7rOy6VbayQfP+E+pMWZ1tzCTR8s
+MAvZijVD/79m6H0SdcwiIfiOUt2mgVpYGYcA4NqdPpKmQJdPHRf4XwIVV+wd+dDs
+gUcp0Nq+fzo47xGm1MGvQx05zO3nfeuvYRbAljF4r/upwkFYmkj1bEJ50MgbZdS8
+vgTUe8pvcjOpL6P+8f9q4rBctvnzQ1DZqwOj+9IbydekHhJ7oJXZYbnolh+ZKlPB
+AgMBAAGjaTBnMB0GA1UdDgQWBBR8hkA4Jl0bRUPG8H3JATeEXl6J3DBGBgNVHREE
+PzA9ghF0ZXN0LWlkcC51bmluZS5jaIYoaHR0cHM6Ly90ZXN0LWlkcC51bmluZS5j
+aC9pZHAvc2hpYmJvbGV0aDANBgkqhkiG9w0BAQsFAAOCAQEAbtdMBv5hd4K+EuAz
+BNxwb++FiV9fRP7+wsCUtZAmvkdX9TkpxGru3jrVS2tN9kd45PiPT/qCGaMx3LgY
+XuhgwI49VYL7es6Soc3aQAY90zwqYhKFT+OJp7wsrKRZdSz5g2VPCJKiMpLY7g8f
+mtYCDIMG2A2gkQl2Zqekm8CH5qgEz3XBCZQ19h5wQYrJk6VCAJY78irhFUPWsxIR
+m/2zNvNzNBGi9p84KZ+Fn9S9GaFIx2wm9mWFCGQ4ClGXyXL9jnNADyYlrjuN30uA
+8lmloJmoOlIepR1/G4fPcVOndbEGUX5QbY+MMlK9KXR34evTNSYvP6XjwxWpXw2d
+1c2eAQ==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://test-idp.unine.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://test-idp.unine.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">test-idp.unine.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">Université de Neuchâtel - test IdP</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.test-idp.unine.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- CHUV Test IdP -->
+	<md:EntityDescriptor entityID="https://testidp.chuv.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.chuv.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">CHUV Test IdP</mdui:DisplayName>
+					<mdui:Description xml:lang="en">Test Identity Provider for CHUV</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>test.chuv.ch</mdui:DomainHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDHDCCAgSgAwIBAgIJAIFKA1sTa3AJMA0GCSqGSIb3DQEBBQUAMBoxGDAWBgNV
+BAMTD3Rlc3RpZHAuY2h1di5jaDAeFw0xNzA5MjYxNTExMzJaFw0yMDA5MjUxNTEx
+MzJaMBoxGDAWBgNVBAMTD3Rlc3RpZHAuY2h1di5jaDCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBALwrljXaodU+DL/oIfgT0XeD79A8nNly1L4JTlJ1XZVi
+kBE+zslCHxkRgcM6Pt8ECKG8/YE6N+9uxclOOFKWCb+bkaOBYVEbwoCYWq6j9PIW
+Zy0XD3a8tg6IiN0KpnSlKU3V5Tsax+QcIKz4cBce37UnoEkFJs2fH/BSWMSfrXXF
+MAh6tbTBIKAht+YEQi1P+S1mWZpwoXXyWfYylq76UC0WV0q95NoNi3ONoqjRY5iJ
+TspAGt8vlqctxvfvAoYkothWgX6KsjKIZSP+9KQu88KVjaHQLsaxh3ucm07fK9jW
+/eSDRyJ5sxlmXWLemBiqeACNvtSq9fuwX+UaVEGdd8ECAwEAAaNlMGMwQgYDVR0R
+BDswOYIPdGVzdGlkcC5jaHV2LmNohiZodHRwczovL3Rlc3RpZHAuY2h1di5jaC9p
+ZHAvc2hpYmJvbGV0aDAdBgNVHQ4EFgQUCf0XpzMWYAo8QtPkt5xETSg4RX4wDQYJ
+KoZIhvcNAQEFBQADggEBAEsgQuXiXj9zb4isAtj25GX71nx1z7JBo/N4k9pJzAgU
+PfVkA7nrm1Nb4GlXqG9DWruREq2D+5GxzUfXWnrM+CzxzgU6kawlYyrydG7jULQ0
+7rvySpL9Y9+KkzWdRZXL3Lf6IFpd9IwxKB8kA56R4A9U1El4UaC9rmxAYAYpkImM
+fMNeeiF2qbq9ft5NHiWEgOSpO/TkXf1pYLNXc6MsRwqq4sGCZ/gZu+A9bulUEhV/
+Y9gU57+7zUQQr6AwD1EQeXwYaZqijLn627SoiNCuxiCvxBhKyhupjUtPhTC9pdIE
+K/Ry6U7sfhKgKvE76zKVzuNbTS8HqzEkLi08JNGBgWc=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://testidp.chuv.ch:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://testidp.chuv.ch:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://testidp.chuv.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://testidp.chuv.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://testidp.chuv.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://testidp.chuv.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.chuv.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDHDCCAgSgAwIBAgIJAIFKA1sTa3AJMA0GCSqGSIb3DQEBBQUAMBoxGDAWBgNV
+BAMTD3Rlc3RpZHAuY2h1di5jaDAeFw0xNzA5MjYxNTExMzJaFw0yMDA5MjUxNTEx
+MzJaMBoxGDAWBgNVBAMTD3Rlc3RpZHAuY2h1di5jaDCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBALwrljXaodU+DL/oIfgT0XeD79A8nNly1L4JTlJ1XZVi
+kBE+zslCHxkRgcM6Pt8ECKG8/YE6N+9uxclOOFKWCb+bkaOBYVEbwoCYWq6j9PIW
+Zy0XD3a8tg6IiN0KpnSlKU3V5Tsax+QcIKz4cBce37UnoEkFJs2fH/BSWMSfrXXF
+MAh6tbTBIKAht+YEQi1P+S1mWZpwoXXyWfYylq76UC0WV0q95NoNi3ONoqjRY5iJ
+TspAGt8vlqctxvfvAoYkothWgX6KsjKIZSP+9KQu88KVjaHQLsaxh3ucm07fK9jW
+/eSDRyJ5sxlmXWLemBiqeACNvtSq9fuwX+UaVEGdd8ECAwEAAaNlMGMwQgYDVR0R
+BDswOYIPdGVzdGlkcC5jaHV2LmNohiZodHRwczovL3Rlc3RpZHAuY2h1di5jaC9p
+ZHAvc2hpYmJvbGV0aDAdBgNVHQ4EFgQUCf0XpzMWYAo8QtPkt5xETSg4RX4wDQYJ
+KoZIhvcNAQEFBQADggEBAEsgQuXiXj9zb4isAtj25GX71nx1z7JBo/N4k9pJzAgU
+PfVkA7nrm1Nb4GlXqG9DWruREq2D+5GxzUfXWnrM+CzxzgU6kawlYyrydG7jULQ0
+7rvySpL9Y9+KkzWdRZXL3Lf6IFpd9IwxKB8kA56R4A9U1El4UaC9rmxAYAYpkImM
+fMNeeiF2qbq9ft5NHiWEgOSpO/TkXf1pYLNXc6MsRwqq4sGCZ/gZu+A9bulUEhV/
+Y9gU57+7zUQQr6AwD1EQeXwYaZqijLn627SoiNCuxiCvxBhKyhupjUtPhTC9pdIE
+K/Ry6U7sfhKgKvE76zKVzuNbTS8HqzEkLi08JNGBgWc=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://testidp.chuv.ch:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://testidp.chuv.ch:8443/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">test.chuv.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">CHUV Test IdP</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.test.chuv.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- SWITCH edu-ID [Test] -->
+	<md:EntityDescriptor entityID="https://test.eduid.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.eduid.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="de">SWITCH edu-ID [Test]</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="en">SWITCH edu-ID [Test]</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="fr">SWITCH edu-ID [Test]</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="it">SWITCH edu-ID [Test]</mdui:DisplayName>
+					<mdui:Description xml:lang="de">SWITCH edu-ID Test Identity Provider</mdui:Description>
+					<mdui:Description xml:lang="en">SWITCH edu-ID Test Identity Provider</mdui:Description>
+					<mdui:Description xml:lang="fr">SWITCH edu-ID Test Identity Provider</mdui:Description>
+					<mdui:Description xml:lang="it">SWITCH edu-ID Test Identity Provider</mdui:Description>
+					<mdui:Keywords xml:lang="en">demo</mdui:Keywords>
+					<mdui:Logo height="16" width="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAA5UlEQVR4nGL4//8/AyWYIs1gAx4+ea8oqtvwH4STi1f9BwkqW3X8h4nBsJRR839jjwn/MyrWLr336J0KyQYgYz2Xvidfvv3iIWiApn33/8VrzqaC8KS5R8ot/abADVmy9lwKQQPMvCb9R/bvhh1X4Aa0TNjTTrIB+4/dhRtQ2LBpNkUGFNRvmkOyATsP3IQbUNy4eSbJBnRPPwA3oG3yvhaCBqhYd/xvnbS3FYSzKtctBqUFmNpl688nkZ0O1Gw633799oubJAPE9Br/6zr3/o/MWrr19v03GtTLCwNuAAAAAP//AwBc/4FSWnrPgwAAAABJRU5ErkJggg==</mdui:Logo>
+					<mdui:Logo height="60" width="80">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAA8CAYAAADxJz2MAAAACXBIWXMAAAk6AAAJOgHwZJJKAAAHRklEQVR4nOxbCWgeRRRe7wvxwAsVPFEUwXt3/z+pjZJUq7QeGDxQUbFFqgYVvJUqKgoxOrN/jkZaWuNVo8XaoiCKwQNiija2BbH6W6O1RoxojY3Wqo3z3s61/86ff/Pv1u3S/8Ej/+6+efPm2zdv3s68WMVi0apx9Zy6AVnn1A3IOqduQNY5dQOyzqkbkHVO3YCsc+oGZJ1TNyDrnLoBWefgBZDtTbEc2mPZ5AvGI+z3P4x/t2z6reWQPsZzrObeXVDWIR8zme/Y8zctEzmkCZ+jDPnGmtazT0imvvMA1I1ytM1vR5fydu/z6wGpZyJ2yKdSb67jeNaulXE/01tkvJE9/5v9HWa80nLpA1Zj937K1pI+zeN5RvRlBjDnnc6Ub2EC4xMzncs7fR6vAeSGhfsbOqSBdg69MCzjXa5kvOu43n4u/yW/Xl/ZJrRr2HeCwnns99aK8g5ZrAEY7NMIIDoWtjUDaNNObbDdjM9kxhyDb9MtTGfXv5QM7AZlUOGSUIc2XVsCIDEY1S2f1xUOLwPgLYzvk2yTX/nzdYH7Lr2Ny6/mOv/yX6J3lZUrnM/+XsR1bZB9TvEOTg5Ah77N3+RmKzf/QIMC7nFsKjw8vrOVbz9KGuJ6hSB4DHgF3BBv97lB57rQs0qD8af8uHG6wUxQ/b5qbk/u0F7aWUkC+B5X8ptZATnUcjtOQh4f34kPpmgEx6U3887+Rc+Qg/KOlDJ57zhtOtFEAMzTUzSvv9/YPudNZbrfQXbbneQAtOkiLZ60cbc/1WroOEwCFgb12dAU9DtbyvWsDHqjd6MBZPDgGYkA6HjTNABvLQtGGBzR53qmwzUzeauCB+KqWS7oQjz5CmNWXeeJWsdXalPmWrw3u3s3JjvK77VyoL8PB26yRIaEugX7JgIgvnTDy4oKYEQun8bk6AVMoBenpE3Hyij4msWaPVE+33WI5rWLfB1siijPauRgPcfvjWD8BJaLAfmojDdU4YH0XNU3ven/B7CUIE+r7zyWrcINOFChJE/O1ga0hgNY5NeP8esxa7q3BwfwGtW24zRkBfzcxADMeXbMKRwnBpJm5jGz0AtNlKNXa551maaYKHCYR/oJ9jjGDCnDFiDlGXfi4OR1oW5Sg5kIwODq/5Cxvf/yNiFDHE4MQD/jB49YUUbBxdqq2STvu4WZ6q2znAszfgS5paT9Kt72ddbHC/z3qNXQt2tiAEJogcTeb99jbA8LlvLS5iQBfJkDuBkTZ8ipYHDNvbv7b5Yulx3rCwl8EimjB4wyvgGtMg6K/M+mywyGVg+g/3wNfzl/MLAexJgMqRdkFJDwO/QzbaFxkwMwRy+NFEQBJFgEgsoHgjLs2zdkQCDFEKGgJSwXF0AtUZ54HKvUd30SAAJBDIQpDF4Y7Aw87AcGzDxMgMPKnygBcF5IJte7F5P7Mwgg84ykAUQd7GU59EPfZj47xDgc+iPmr8F0LCEAdZrRvTcmxzBFyyXSWSDwMvgYgJCU0DiipzE1MlINwJhUAzAm1QCMSTUAY1INwJhUAzAm1QCMSTUAY1INwJiUPoCw7a8OxJsqN4hApsNxdc/AsGtDl+EGMGwcT4K2FwDFhurMRHSaNgQib9XTn/BELyLtgADSYayCEOzvvreos3DcQVoStasdD8By21SwO2OTQQ7yVtxyi0DxAYTKBYc8ijEEinrAUKgEgPqW0s1W2D906Xw8lILDbJs8aTV0HxQC0KYvokfAxq5OcLoG9/XDdxNVA6Dfb5u0BcpYIlA8AOEtwUaleGs2/dnCCi65Tf6UkkWgR8O7wdoJnwBQnh17t5cA0yp3wieiagF0vXsUgN7UKBDEA9Chsy1xIARnJcqQWdyQTfI4E+KM2AmGcxYocYNNWnGotD0ACAVH6oihMQoEcQEkHMC+wH0ERhjSdTSXbecD6A/q8E6uGkCoedEZTgt9uSoBJHOkLfn2c6JAEA9Am77Cp++Y5ZeYCR7SprHLB9vLwX4joEOvopo8gKXh4CUuV60H3qtsaT8jCgQxPZAs5gCuZQH+aSOLYAwLQ2wAeaGmBJC+G2RehVV1DGT2yhjYdUQUCOIBCLWAPoDLA/dh9YXyNWAVAwt8AB8EZPUKAgmgqESldwdkHfrJNo6Bq+WMEsecFSjmFPbu4kZtkEAB6ZVRYiqIFQ4OueFkTJBeM6jSmBVySsr6Q61cNw6A8OkGtYCCczTP+r3Cr5KQoaBvAu0Bigegv4pu4cYOYf6HOaBIbZixkCgD1befoH0ubcSzWqgMAPChkFMH0PUe12LbCJbT+X3E98BKDC+4XE1Q4gACgbdhEZFWAgdGOPS1UEmH612v4hsecg9iaa0obxMAQorjkIXyUB8WJijNcMgj2wRAPz8dxIVuEt/BQMl+ysHBu/4vA+UIDupN/+pQShBLo+hLkYwA1njynLoBWefUDcg6p25A1jl1A7LOqRuQdU7dgKxz6gZknVM3IOucugFZ5/8AAAD//wMAsSmtb9lwCXsAAAAASUVORK5CYII=</mdui:Logo>
+					<mdui:InformationURL xml:lang="en">https://projects.switch.ch/eduid/</mdui:InformationURL>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>eduid.ch</mdui:DomainHint>
+					<mdui:DomainHint>edu-id.ch</mdui:DomainHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDIDCCAgigAwIBAgIVANt+in4DKHpdPEdzf7EKsoI+xrUyMA0GCSqGSIb3DQEB
+CwUAMBgxFjAUBgNVBAMMDXRlc3QuZWR1aWQuY2gwHhcNMTcxMDMxMDgyNTQzWhcN
+MjAxMDMxMDgyNTQzWjAYMRYwFAYDVQQDDA10ZXN0LmVkdWlkLmNoMIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAobHkbul8u6SEpc4C3/fkkwGYcthsFQC+
+ILWKrK7D2Mnt/OdZrkFrNVCaDi6dl/T6tN8ESrpCxqG9jUxlgxHr0L2LlN2ilqiB
+FkY1zM/OkJa2WarQZ9dkP4dfjLdp2T17MkPZvTCMoHqzyK7WvFCGAa5JxXubKmh+
+KjuNzGA/4Y3Vm+Y8Qs/wbpHeMXVk+Oeke6Qnqs1JfMXIWGD81AYbUjHaBIhF1J5u
+8iJe0zTJ8MSuPdMOLEY/4KSWKtT0HM/LRAH4iRKdq+B3Cl+WZGKgd864GQ1HkxHZ
+1xx7H1TisWzUIyeeuO1n6MNa9+kcLal2p2C7q+wuC8BWLDXlut+VxwIDAQABo2Ew
+XzAdBgNVHQ4EFgQUfGdP74lJsTJldXc4hVRkM5KX6oEwPgYDVR0RBDcwNYINdGVz
+dC5lZHVpZC5jaIYkaHR0cHM6Ly90ZXN0LmVkdWlkLmNoL2lkcC9zaGliYm9sZXRo
+MA0GCSqGSIb3DQEBCwUAA4IBAQCUBMahAkFjp+9B5fMjqM6ZCj/zC7UgM2DBBxm4
+YQaSSfjNGz1YC0fVDpoH1qVf0m9Ig7tI4QOAipzlwrKgCbB++KTxsXQBtfw2EBbg
+hfNphXCU0b855FUirnJWN+T2t3APq68dII3KkRPQ8uSq7JN7Ccm38RzmbQ9gt1RR
+4IVqHf/TstovqXC1sf/bDM9IBqvsZyD/043i1uwOQyiuZyOUS5J15BnKmo2N0NLz
+9E5IDu+3NpnlwBcqCaXPZhYSoTGZJfPE8MPzlP3tDoElEK07dOzyOF8mlnioqd0q
+OKNguza3bi3RRsZUlDAJHSGHm+Fc3QLUPCDLZc0+OKcQbThC
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://login.test.eduid.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="1"/>
+			<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.test.eduid.ch/idp/profile/SAML2/Redirect/SLO"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://login.test.eduid.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://login.test.eduid.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://login.test.eduid.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://login.test.eduid.ch/idp/profile/SAML2/SOAP/ECP"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.eduid.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDIDCCAgigAwIBAgIVANt+in4DKHpdPEdzf7EKsoI+xrUyMA0GCSqGSIb3DQEB
+CwUAMBgxFjAUBgNVBAMMDXRlc3QuZWR1aWQuY2gwHhcNMTcxMDMxMDgyNTQzWhcN
+MjAxMDMxMDgyNTQzWjAYMRYwFAYDVQQDDA10ZXN0LmVkdWlkLmNoMIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAobHkbul8u6SEpc4C3/fkkwGYcthsFQC+
+ILWKrK7D2Mnt/OdZrkFrNVCaDi6dl/T6tN8ESrpCxqG9jUxlgxHr0L2LlN2ilqiB
+FkY1zM/OkJa2WarQZ9dkP4dfjLdp2T17MkPZvTCMoHqzyK7WvFCGAa5JxXubKmh+
+KjuNzGA/4Y3Vm+Y8Qs/wbpHeMXVk+Oeke6Qnqs1JfMXIWGD81AYbUjHaBIhF1J5u
+8iJe0zTJ8MSuPdMOLEY/4KSWKtT0HM/LRAH4iRKdq+B3Cl+WZGKgd864GQ1HkxHZ
+1xx7H1TisWzUIyeeuO1n6MNa9+kcLal2p2C7q+wuC8BWLDXlut+VxwIDAQABo2Ew
+XzAdBgNVHQ4EFgQUfGdP74lJsTJldXc4hVRkM5KX6oEwPgYDVR0RBDcwNYINdGVz
+dC5lZHVpZC5jaIYkaHR0cHM6Ly90ZXN0LmVkdWlkLmNoL2lkcC9zaGliYm9sZXRo
+MA0GCSqGSIb3DQEBCwUAA4IBAQCUBMahAkFjp+9B5fMjqM6ZCj/zC7UgM2DBBxm4
+YQaSSfjNGz1YC0fVDpoH1qVf0m9Ig7tI4QOAipzlwrKgCbB++KTxsXQBtfw2EBbg
+hfNphXCU0b855FUirnJWN+T2t3APq68dII3KkRPQ8uSq7JN7Ccm38RzmbQ9gt1RR
+4IVqHf/TstovqXC1sf/bDM9IBqvsZyD/043i1uwOQyiuZyOUS5J15BnKmo2N0NLz
+9E5IDu+3NpnlwBcqCaXPZhYSoTGZJfPE8MPzlP3tDoElEK07dOzyOF8mlnioqd0q
+OKNguza3bi3RRsZUlDAJHSGHm+Fc3QLUPCDLZc0+OKcQbThC
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://login.test.eduid.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">test.eduid.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="de">SWITCH edu-ID [Test]</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="en">SWITCH edu-ID [Test]</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="fr">SWITCH edu-ID [Test]</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="it">SWITCH edu-ID [Test]</OrganizationDisplayName>
+			<OrganizationURL xml:lang="de">http://www.test.eduid.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="en">http://www.test.eduid.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="fr">http://www.test.eduid.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="it">http://www.test.eduid.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- FHNW-TEST - Fachhochschule Nordwestschweiz -->
+	<md:EntityDescriptor entityID="https://aai-logon.test.fhnw.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.fhnw.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="de">FHNW-TEST - Fachhochschule Nordwestschweiz</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="en">FHNW-TEST - Fachhochschule Nordwestschweiz</mdui:DisplayName>
+					<mdui:Description xml:lang="de">TEST-IdP - Fachhochschule Nordwestschweiz (Shib2.1)</mdui:Description>
+					<mdui:Description xml:lang="en">TEST-IdP - Fachhochschule Nordwestschweiz (Shib2.1)</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>test.fhnw.ch</mdui:DomainHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDRDCCAiygAwIBAgIVALQBLlOzW4zwhaqVc3SuSpdnEm0LMA0GCSqGSIb3DQEB
+CwUAMCExHzAdBgNVBAMMFmFhaS1sb2dvbi50ZXN0LmZobncuY2gwHhcNMTcwMzE0
+MDkyOTU3WhcNMjAwMzE0MDkyOTU3WjAhMR8wHQYDVQQDDBZhYWktbG9nb24udGVz
+dC5maG53LmNoMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmMD/WWZk
+owM8ibA7NOwhOfIwi6xXWL+5tPXPitPIDM3Taa4O2hw7ZTvGK22vMMLwyp8aCYY/
+Obp58vmt5PBiCCx0WOiiK/5gSWWEd2yVgbx3BPz4aeQ71qvWN6j7WMbk6IhSe9+j
+LonEq0VAEhhSFZIwAQdLbCL70KKIalsnc1DBBt2e1MkoCrXVqewCLGrD73U7L3zy
+UfFkkF4ZB8rf1Ii+P75HfTnX2qtKfUMXhTWEH07Pox3tU5yi+gpk3Cyt6ZNIEO7A
+JeDf5daaB6DCP8O5v2LX4goKKmjSsPEj3gCz6rCQUOGr6hoaksRqDDIW4AoWM1iX
+nSW72q9fZzgtFwIDAQABo3MwcTAdBgNVHQ4EFgQUWRbn/mXs6+nze8AmSh7XOe+f
+E/0wUAYDVR0RBEkwR4IWYWFpLWxvZ29uLnRlc3QuZmhudy5jaIYtaHR0cHM6Ly9h
+YWktbG9nb24udGVzdC5maG53LmNoL2lkcC9zaGliYm9sZXRoMA0GCSqGSIb3DQEB
+CwUAA4IBAQBeAZzDVXAwEk7DvIpbCs5Ci6dBAO70seH26Z3ty82l/31muvDdJHSM
+1BIzK/UKEXcEHUaCJoP3IoKreLq/8kGYrX1RXh5imroyV0JyS/5AsVuXeB4W0B4M
+cfy5cx7OePhkFtDYQM1pvN5SyhkAbh5dDkV4G4dMYdlYOmcWoM6oLapOLfdv2OuT
+qHl/ZgVLWoLw51SlUOtaw0dLW9b2RGwK3DXqxljz5cTtkuTlt8BjQPv0so6362qG
+T8R8+VbJBuP4wcINR8q/e+/OKweDxqiMBnzaigp69vDeEIhTpg4y8LSACdsEQsf0
+yAC9nH+QiapYyPz1qWWsvFRG7/lpA2hc
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon.test.fhnw.ch:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon.test.fhnw.ch:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon.test.fhnw.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon.test.fhnw.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon.test.fhnw.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aai-logon.test.fhnw.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.fhnw.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDRDCCAiygAwIBAgIVALQBLlOzW4zwhaqVc3SuSpdnEm0LMA0GCSqGSIb3DQEB
+CwUAMCExHzAdBgNVBAMMFmFhaS1sb2dvbi50ZXN0LmZobncuY2gwHhcNMTcwMzE0
+MDkyOTU3WhcNMjAwMzE0MDkyOTU3WjAhMR8wHQYDVQQDDBZhYWktbG9nb24udGVz
+dC5maG53LmNoMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmMD/WWZk
+owM8ibA7NOwhOfIwi6xXWL+5tPXPitPIDM3Taa4O2hw7ZTvGK22vMMLwyp8aCYY/
+Obp58vmt5PBiCCx0WOiiK/5gSWWEd2yVgbx3BPz4aeQ71qvWN6j7WMbk6IhSe9+j
+LonEq0VAEhhSFZIwAQdLbCL70KKIalsnc1DBBt2e1MkoCrXVqewCLGrD73U7L3zy
+UfFkkF4ZB8rf1Ii+P75HfTnX2qtKfUMXhTWEH07Pox3tU5yi+gpk3Cyt6ZNIEO7A
+JeDf5daaB6DCP8O5v2LX4goKKmjSsPEj3gCz6rCQUOGr6hoaksRqDDIW4AoWM1iX
+nSW72q9fZzgtFwIDAQABo3MwcTAdBgNVHQ4EFgQUWRbn/mXs6+nze8AmSh7XOe+f
+E/0wUAYDVR0RBEkwR4IWYWFpLWxvZ29uLnRlc3QuZmhudy5jaIYtaHR0cHM6Ly9h
+YWktbG9nb24udGVzdC5maG53LmNoL2lkcC9zaGliYm9sZXRoMA0GCSqGSIb3DQEB
+CwUAA4IBAQBeAZzDVXAwEk7DvIpbCs5Ci6dBAO70seH26Z3ty82l/31muvDdJHSM
+1BIzK/UKEXcEHUaCJoP3IoKreLq/8kGYrX1RXh5imroyV0JyS/5AsVuXeB4W0B4M
+cfy5cx7OePhkFtDYQM1pvN5SyhkAbh5dDkV4G4dMYdlYOmcWoM6oLapOLfdv2OuT
+qHl/ZgVLWoLw51SlUOtaw0dLW9b2RGwK3DXqxljz5cTtkuTlt8BjQPv0so6362qG
+T8R8+VbJBuP4wcINR8q/e+/OKweDxqiMBnzaigp69vDeEIhTpg4y8LSACdsEQsf0
+yAC9nH+QiapYyPz1qWWsvFRG7/lpA2hc
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon.test.fhnw.ch:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon.test.fhnw.ch:8443/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">test.fhnw.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="de">FHNW-TEST - Fachhochschule Nordwestschweiz</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="en">FHNW-TEST - Fachhochschule Nordwestschweiz</OrganizationDisplayName>
+			<OrganizationURL xml:lang="de">http://www.test.fhnw.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="en">http://www.test.fhnw.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- SWITCH IdP Hosting Test Login -->
+	<md:EntityDescriptor entityID="https://test.idph.switch.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.idph.switch.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">SWITCH IdP Hosting Test Login</mdui:DisplayName>
+					<mdui:Description xml:lang="en">Test login for SWITCH IdP hosting</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIEODCCAqCgAwIBAgIVAP43AtdifZVfQNYTobI//5crLGojMA0GCSqGSIb3DQEB
+CwUAMB4xHDAaBgNVBAMME3Rlc3QuaWRwaC5zd2l0Y2guY2gwHhcNMTkwMjEyMDkz
+NDEyWhcNMjIwMjEyMDkzNDEyWjAeMRwwGgYDVQQDDBN0ZXN0LmlkcGguc3dpdGNo
+LmNoMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAzYISRHv4J2jd4aUC
+tdOA2Sv56tPUp6qLPsdhSw2drS8rIAwpKCh1fIp9tfJsSZgcCizhZCnNPTM+zUi6
+Dra+AtpiW+hwvz6tI3XLQstxzm6a67vzBkqTxvci0TPlooYqruIboCgUZdUyDwW8
+0nDCXNj0OTlU9b5KHGJf9Jdtj1e55nKy6Q3RvUP2sRNJGo73BXW8VgF0vzPFMYD8
+YGzu/NqMlGqZ4juTLjV+qJuDQWxKjKcTWRwDLV26Or7gIdxcXMzINdMYzc0Gas+e
+Kab/rQnnqru3HIk18tbyenWlXZrv1k2715238ASbn+GzJJ6gq1wy2pmfZ7rC98FN
+EyDp9xbXGQRRNpeVePillgo9hrHZFLHfOcmOx8sAwd6072uI58WtU2HTcqmpKPpU
+Rkx6BR37wD4m9X1XbbVuEl2c7f+eHYPoWWfmsOPEuW/1hL6n/32pVIMvBCJ0z+Al
+M5/jD0pXTschx1O3azhkPwv/1zHV7s/tZQvd0O0FW506pBUpAgMBAAGjbTBrMB0G
+A1UdDgQWBBRtL10/JunohYCyQbuxx/rSoFJSXTBKBgNVHREEQzBBghN0ZXN0Lmlk
+cGguc3dpdGNoLmNohipodHRwczovL3Rlc3QuaWRwaC5zd2l0Y2guY2gvaWRwL3No
+aWJib2xldGgwDQYJKoZIhvcNAQELBQADggGBAKdsNec8sw4JCRE/FPDwwi7RVlQj
+OWQg5bkGXTDYSNlsU9IeORD8lZS0b18pEQXTWadyNiyrnaJwSfh4olHUuRJEG9cR
+45JoScrg8Qsvd/qo/QmDty02MYEdFhBdIKhqEX28pi+fwHfQ/C4MA9Opgh02LgEN
+T/JRhzAeJVAalJV/5XKA60yUGzBWtWeQY0MZh1T8ZMAaZPvetqomO2RaR6YnW2/f
+z+0p2SYlBrZkcCC6L7UweT/exi1so+PMnQaQSZ/OomPgpAKTw+9592WToCzXyfyf
+3oTBRje5YP2LYtqsemgtEmnrSAK2UyQ9IgW/feij5HqJFsMBkP7wHKvzPqmRnMR8
+PPJpszWP7MRYRXCSULfZkuFAulag/gh9cvDijz5EGNUuQIDDVHfn/aVDE7W2jsz6
+9H1Vbf2cBSQkAyePTXbmEb8cDRq3l+tZyTx2uCRA1LppYaD7WpBM07AZTEMnj85o
+I+Gw1TCc5NpI1S7PWrG94x7O9SnYNL/OzyLNew==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://test.idph.switch.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="1"/>
+			<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test.idph.switch.ch/idp/profile/SAML2/Redirect/SLO"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test.idph.switch.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.idph.switch.ch/idp/profile/SAML2/POST/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.idph.switch.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIEODCCAqCgAwIBAgIVAP43AtdifZVfQNYTobI//5crLGojMA0GCSqGSIb3DQEB
+CwUAMB4xHDAaBgNVBAMME3Rlc3QuaWRwaC5zd2l0Y2guY2gwHhcNMTkwMjEyMDkz
+NDEyWhcNMjIwMjEyMDkzNDEyWjAeMRwwGgYDVQQDDBN0ZXN0LmlkcGguc3dpdGNo
+LmNoMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAzYISRHv4J2jd4aUC
+tdOA2Sv56tPUp6qLPsdhSw2drS8rIAwpKCh1fIp9tfJsSZgcCizhZCnNPTM+zUi6
+Dra+AtpiW+hwvz6tI3XLQstxzm6a67vzBkqTxvci0TPlooYqruIboCgUZdUyDwW8
+0nDCXNj0OTlU9b5KHGJf9Jdtj1e55nKy6Q3RvUP2sRNJGo73BXW8VgF0vzPFMYD8
+YGzu/NqMlGqZ4juTLjV+qJuDQWxKjKcTWRwDLV26Or7gIdxcXMzINdMYzc0Gas+e
+Kab/rQnnqru3HIk18tbyenWlXZrv1k2715238ASbn+GzJJ6gq1wy2pmfZ7rC98FN
+EyDp9xbXGQRRNpeVePillgo9hrHZFLHfOcmOx8sAwd6072uI58WtU2HTcqmpKPpU
+Rkx6BR37wD4m9X1XbbVuEl2c7f+eHYPoWWfmsOPEuW/1hL6n/32pVIMvBCJ0z+Al
+M5/jD0pXTschx1O3azhkPwv/1zHV7s/tZQvd0O0FW506pBUpAgMBAAGjbTBrMB0G
+A1UdDgQWBBRtL10/JunohYCyQbuxx/rSoFJSXTBKBgNVHREEQzBBghN0ZXN0Lmlk
+cGguc3dpdGNoLmNohipodHRwczovL3Rlc3QuaWRwaC5zd2l0Y2guY2gvaWRwL3No
+aWJib2xldGgwDQYJKoZIhvcNAQELBQADggGBAKdsNec8sw4JCRE/FPDwwi7RVlQj
+OWQg5bkGXTDYSNlsU9IeORD8lZS0b18pEQXTWadyNiyrnaJwSfh4olHUuRJEG9cR
+45JoScrg8Qsvd/qo/QmDty02MYEdFhBdIKhqEX28pi+fwHfQ/C4MA9Opgh02LgEN
+T/JRhzAeJVAalJV/5XKA60yUGzBWtWeQY0MZh1T8ZMAaZPvetqomO2RaR6YnW2/f
+z+0p2SYlBrZkcCC6L7UweT/exi1so+PMnQaQSZ/OomPgpAKTw+9592WToCzXyfyf
+3oTBRje5YP2LYtqsemgtEmnrSAK2UyQ9IgW/feij5HqJFsMBkP7wHKvzPqmRnMR8
+PPJpszWP7MRYRXCSULfZkuFAulag/gh9cvDijz5EGNUuQIDDVHfn/aVDE7W2jsz6
+9H1Vbf2cBSQkAyePTXbmEb8cDRq3l+tZyTx2uCRA1LppYaD7WpBM07AZTEMnj85o
+I+Gw1TCc5NpI1S7PWrG94x7O9SnYNL/OzyLNew==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://test.idph.switch.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">test.idph.switch.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">SWITCH IdP Hosting Test Login</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.test.idph.switch.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- University of Bern Test IdP -->
+	<md:EntityDescriptor entityID="https://aai-login.test.unibe.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor errorURL="http://www.id.unibe.ch/content/helpdesk/index_ger.html" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.unibe.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="de">Universität Bern Test IdP</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="en">University of Bern Test IdP</mdui:DisplayName>
+					<mdui:Description xml:lang="de">Test IdP Instanz der Universität Bern</mdui:Description>
+					<mdui:Description xml:lang="en">University of Bern test IdP instance</mdui:Description>
+					<mdui:InformationURL xml:lang="en">http://www.unibe.ch/</mdui:InformationURL>
+					<mdui:InformationURL xml:lang="de">http://www.unibe.ch/</mdui:InformationURL>
+					<mdui:PrivacyStatementURL xml:lang="en">http://www.rechtsdienst.unibe.ch/content/rechtssammlung/informatik/index_ger.html</mdui:PrivacyStatementURL>
+					<mdui:PrivacyStatementURL xml:lang="de">http://www.rechtsdienst.unibe.ch/content/rechtssammlung/informatik/index_ger.html</mdui:PrivacyStatementURL>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:IPHint>130.92.0.0/16</mdui:IPHint>
+					<mdui:DomainHint>unibe.ch</mdui:DomainHint>
+					<mdui:GeolocationHint>geo:46.9505,7.43814</mdui:GeolocationHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDSDCCAjCgAwIBAgIVAIfsb4anTrY/mdF71i0xrMTwNFH9MA0GCSqGSIb3DQEB
+CwUAMCIxIDAeBgNVBAMMF2FhaS1sb2dpbi50ZXN0LnVuaWJlLmNoMB4XDTE4MDEy
+MjA3NDMxOVoXDTIxMDEyMjA3NDMxOVowIjEgMB4GA1UEAwwXYWFpLWxvZ2luLnRl
+c3QudW5pYmUuY2gwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCxYu8S
+rV0nAkV7Es07ht/pUjsYuDbfe1r+wEHjObunZFIw32weHCpfUYNmd1JhoS7bFOYL
+CnRFOU76no7PB8TcyjxkCfaVgm60OJaFjyH2FWbPUtYmY4h2nYreonsV4M3VyK49
+vebEQGnhGcEE/jMTvsDq7Z7paYn1Z0y6tAheNGGndGlFWvSsA8oIpi09gFpRdowE
+vkk/SHRdzzk4IhFTaVbNsS8l+XMdT+tJlzyonB3L4+5Kych7K5LeytQdLIvVZaqy
+6l0aDbR+isK8U/+HHL8uJ2C9ZBE/t0XvQ/+ADHPQkb+1dF87Z5h0VdYvp8dgH8XP
+9qLqj1OWk1P5bl7xAgMBAAGjdTBzMB0GA1UdDgQWBBQ5prtWUCE5RxfSVadvUPVf
+bTT1szBSBgNVHREESzBJghdhYWktbG9naW4udGVzdC51bmliZS5jaIYuaHR0cHM6
+Ly9hYWktbG9naW4udGVzdC51bmliZS5jaC9pZHAvc2hpYmJvbGV0aDANBgkqhkiG
+9w0BAQsFAAOCAQEATatl0/dIFePkD1t9ONdkjAO8jKuNPfVdXYgdAi+24lMil92T
+pxoZSgYqP6kFDYnyPzGW/1kmJ3ZKd0znBThforK/w4dBEN8TFqBo2VA1m9BoQvd9
+3d1SIq9dt67Ti6IaqbS/bFy5bjxPR7CVgAsrP7WX5vrKJCSvUN6wd3DG9wNSRx+v
+HZVikT+qm32dI3ZQVaRctAwbZP56f2Yd0Wt7weuq7yQno/2UgvH30JUeFc2tZyKh
+Iv6IdEgknQtJLEjyzMluU2YeaogGL1ghA8HsPYkKDLY01n27nQU27jXNud9aTYHt
+iHTraMOaCZWrdTour6KckJigCYEL6t11LM0eNw==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-login.test.unibe.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-login.test.unibe.ch/idp/profile/SAML2/POST/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.unibe.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDSDCCAjCgAwIBAgIVAIfsb4anTrY/mdF71i0xrMTwNFH9MA0GCSqGSIb3DQEB
+CwUAMCIxIDAeBgNVBAMMF2FhaS1sb2dpbi50ZXN0LnVuaWJlLmNoMB4XDTE4MDEy
+MjA3NDMxOVoXDTIxMDEyMjA3NDMxOVowIjEgMB4GA1UEAwwXYWFpLWxvZ2luLnRl
+c3QudW5pYmUuY2gwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCxYu8S
+rV0nAkV7Es07ht/pUjsYuDbfe1r+wEHjObunZFIw32weHCpfUYNmd1JhoS7bFOYL
+CnRFOU76no7PB8TcyjxkCfaVgm60OJaFjyH2FWbPUtYmY4h2nYreonsV4M3VyK49
+vebEQGnhGcEE/jMTvsDq7Z7paYn1Z0y6tAheNGGndGlFWvSsA8oIpi09gFpRdowE
+vkk/SHRdzzk4IhFTaVbNsS8l+XMdT+tJlzyonB3L4+5Kych7K5LeytQdLIvVZaqy
+6l0aDbR+isK8U/+HHL8uJ2C9ZBE/t0XvQ/+ADHPQkb+1dF87Z5h0VdYvp8dgH8XP
+9qLqj1OWk1P5bl7xAgMBAAGjdTBzMB0GA1UdDgQWBBQ5prtWUCE5RxfSVadvUPVf
+bTT1szBSBgNVHREESzBJghdhYWktbG9naW4udGVzdC51bmliZS5jaIYuaHR0cHM6
+Ly9hYWktbG9naW4udGVzdC51bmliZS5jaC9pZHAvc2hpYmJvbGV0aDANBgkqhkiG
+9w0BAQsFAAOCAQEATatl0/dIFePkD1t9ONdkjAO8jKuNPfVdXYgdAi+24lMil92T
+pxoZSgYqP6kFDYnyPzGW/1kmJ3ZKd0znBThforK/w4dBEN8TFqBo2VA1m9BoQvd9
+3d1SIq9dt67Ti6IaqbS/bFy5bjxPR7CVgAsrP7WX5vrKJCSvUN6wd3DG9wNSRx+v
+HZVikT+qm32dI3ZQVaRctAwbZP56f2Yd0Wt7weuq7yQno/2UgvH30JUeFc2tZyKh
+Iv6IdEgknQtJLEjyzMluU2YeaogGL1ghA8HsPYkKDLY01n27nQU27jXNud9aTYHt
+iHTraMOaCZWrdTour6KckJigCYEL6t11LM0eNw==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-login.test.unibe.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">test.unibe.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="de">Universität Bern Test IdP</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="en">University of Bern Test IdP</OrganizationDisplayName>
+			<OrganizationURL xml:lang="de">http://www.test.unibe.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="en">http://www.test.unibe.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- Université de Fribourg Test Home Organization -->
+	<md:EntityDescriptor entityID="https://testidp.unifr.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.unifr.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">Université de Fribourg Test Home Organization</mdui:DisplayName>
+					<mdui:Description xml:lang="en">L'Université suisse bilingue. Die zweisprachige Universität.</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>test.unifr.ch</mdui:DomainHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDLDCCAhSgAwIBAgIVANUCuLux+0dmwFD6XbSkJnqRZjXAMA0GCSqGSIb3DQEB
+CwUAMBsxGTAXBgNVBAMMEHRlc3RpZHAudW5pZnIuY2gwHhcNMTgwNjA0MDcyNTUw
+WhcNMjEwNjA0MDcyNTUwWjAbMRkwFwYDVQQDDBB0ZXN0aWRwLnVuaWZyLmNoMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA/9nwpjIYq0d3aihIqVjuNF6E
+VeMnqMmL83YZ5lGCSAW/R1VuJTd81kKd64KPloQio4mypTExwRbAeLtPvXtb3sOP
+SklB4gB3HwphRHFLiW99ApY2DivoMv61LYY30c3yjhpg5PvMkeGyn/iMvizWdBSb
+DQFag5KaHP2eoXPe86yA/ts0Y++U1CwsCOJ/UmaN4wyae/WapR/jmQDqUmsv9LdO
++qcn0XaF0knCg3IiqSeKThs9crKmlUgy6uyydlGdTfiF7DOnVTExwHuPb0WbPQnT
+liENp0+zN6JgQUOaxY2AdXx1XDF45cZZPM12G+8rANnqUX9/L+R6Ub6xeBcY+wID
+AQABo2cwZTAdBgNVHQ4EFgQU9J4bf1tbfSXSD00EoD+kJEGoIwowRAYDVR0RBD0w
+O4IQdGVzdGlkcC51bmlmci5jaIYnaHR0cHM6Ly90ZXN0aWRwLnVuaWZyLmNoL2lk
+cC9zaGliYm9sZXRoMA0GCSqGSIb3DQEBCwUAA4IBAQAv1HiWgLuxIG3ljfnimK1c
+FjrJfjCSv5bshXOZGUtCHM66U/8PLV1E5xxTq5P01yP0dB9UbBEa4bcd/YYDFCFg
+UccxHrNM0iismyG5BNCD26OIBRSSrPNii9iUP/inkr/Dx5BfwmFtXPkYT6/fi4Mo
+/nsK1XR4qtpjmwGFsgKYjZx7wPdhpvcyKOqN4dt/+jJKO+Ay6niG5EUOzYOpZMlB
+trok8KORtkkZGXpZNb8OC2QgFApv46h6KE5JbBIwy9xirqRQQ1elZcuBWYgs3Pbe
+qbvKmYxW/Y+CBrSxVLCBVQboAn6dFKGGIz+fCOY21W7uJCeNrioaeHCnFUB0tYZ6
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://testidp.unifr.ch/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://testidp.unifr.ch/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://testidp.unifr.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://testidp.unifr.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://testidp.unifr.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://testidp.unifr.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.unifr.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDLDCCAhSgAwIBAgIVANUCuLux+0dmwFD6XbSkJnqRZjXAMA0GCSqGSIb3DQEB
+CwUAMBsxGTAXBgNVBAMMEHRlc3RpZHAudW5pZnIuY2gwHhcNMTgwNjA0MDcyNTUw
+WhcNMjEwNjA0MDcyNTUwWjAbMRkwFwYDVQQDDBB0ZXN0aWRwLnVuaWZyLmNoMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA/9nwpjIYq0d3aihIqVjuNF6E
+VeMnqMmL83YZ5lGCSAW/R1VuJTd81kKd64KPloQio4mypTExwRbAeLtPvXtb3sOP
+SklB4gB3HwphRHFLiW99ApY2DivoMv61LYY30c3yjhpg5PvMkeGyn/iMvizWdBSb
+DQFag5KaHP2eoXPe86yA/ts0Y++U1CwsCOJ/UmaN4wyae/WapR/jmQDqUmsv9LdO
++qcn0XaF0knCg3IiqSeKThs9crKmlUgy6uyydlGdTfiF7DOnVTExwHuPb0WbPQnT
+liENp0+zN6JgQUOaxY2AdXx1XDF45cZZPM12G+8rANnqUX9/L+R6Ub6xeBcY+wID
+AQABo2cwZTAdBgNVHQ4EFgQU9J4bf1tbfSXSD00EoD+kJEGoIwowRAYDVR0RBD0w
+O4IQdGVzdGlkcC51bmlmci5jaIYnaHR0cHM6Ly90ZXN0aWRwLnVuaWZyLmNoL2lk
+cC9zaGliYm9sZXRoMA0GCSqGSIb3DQEBCwUAA4IBAQAv1HiWgLuxIG3ljfnimK1c
+FjrJfjCSv5bshXOZGUtCHM66U/8PLV1E5xxTq5P01yP0dB9UbBEa4bcd/YYDFCFg
+UccxHrNM0iismyG5BNCD26OIBRSSrPNii9iUP/inkr/Dx5BfwmFtXPkYT6/fi4Mo
+/nsK1XR4qtpjmwGFsgKYjZx7wPdhpvcyKOqN4dt/+jJKO+Ay6niG5EUOzYOpZMlB
+trok8KORtkkZGXpZNb8OC2QgFApv46h6KE5JbBIwy9xirqRQQ1elZcuBWYgs3Pbe
+qbvKmYxW/Y+CBrSxVLCBVQboAn6dFKGGIz+fCOY21W7uJCeNrioaeHCnFUB0tYZ6
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://testidp.unifr.ch/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://testidp.unifr.ch/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">test.unifr.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">Université de Fribourg Test Home Organization</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.test.unifr.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- Universita della Svizzera Italiana -->
+	<md:EntityDescriptor entityID="https://tlogin.usi.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.unisi.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">Universita della Svizzera Italiana</mdui:DisplayName>
+					<mdui:DisplayName xml:lang="it">Universita della Svizzera Italiana</mdui:DisplayName>
+					<mdui:Description xml:lang="en">Universita della Svizzera italiana</mdui:Description>
+					<mdui:Description xml:lang="it">Universita della Svizzera italiana</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>test.unisi.ch</mdui:DomainHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDHzCCAgegAwIBAgIUBOyIUS+lpmN+gm0OO7ifYxam4OQwDQYJKoZIhvcNAQEL
+BQAwGDEWMBQGA1UEAwwNdGxvZ2luLnVzaS5jaDAeFw0xNzEwMTgxNDIwNDBaFw0y
+MDEwMTgxNDIwNDBaMBgxFjAUBgNVBAMMDXRsb2dpbi51c2kuY2gwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDE7R4SsETnsTZK9iftZrGv6cBk9MTK8rBg
+Z36yGyQJsb29ro6s3l6+Wz1nC2sgKru2AkX8b1qwdYeSFFvrOj8Ux+Pu/CtDqaXs
+etICm3I4d2BPuaLtw+5yWfPb2X+nKBYlrNdNlCII152YzBxVuaIqwShdCyCxhmQN
+a8mk4KinfvxrkFyIcdtBC05ogY8g0XJGwPSkh+KkggGZjTqWqOGbMhxCJgdb/f7a
+tLNH8Pg5BfhpytQ6P3AvX8CKtLOZ/3EUuPdmQpmLKH23P31MQm4UOV0cZKWSvFOX
+MAetmnejFq8L+AVTtkjNeVpApwK25SJBFhf4H/Xcxf6sGjanyHElAgMBAAGjYTBf
+MB0GA1UdDgQWBBSwHQEgW9WPPJ9FvI8gTAJVOxiYlDA+BgNVHREENzA1gg10bG9n
+aW4udXNpLmNohiRodHRwczovL3Rsb2dpbi51c2kuY2gvaWRwL3NoaWJib2xldGgw
+DQYJKoZIhvcNAQELBQADggEBAA9/J7+Ec99rtgh6WOb6mMCVU7yMTSL/l9y5Y1hV
+h/le4sLpHhCYBBwVEDqjOhtZBczwpfJNx5NHwK1k/5upsgAOyF3ASfxM91MrRcfL
+Ed3voQETuZ158NxYVc6jVoEhIZd41varJgqXWq3udYtX5qxzB9mtkQAFtEHwb5Ef
+7Y61JIhlZUsM3amqPrglaGgg6Cp+kzGaOLJfMwo/P1liWaQOxctM0DUvm1xBzOpA
+PIR6n9TcuIrrjSOKccQkfLNs+WFFD0pLZgl7Qcv18y7031/mQLDi4SF2R/zZuolo
+1uM1eVF6cluVa5tdvdgOSrnIfoLKHQskjzm7Xwd4vHrI924=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://tlogin.usi.ch:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://tlogin.usi.ch:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://tlogin.usi.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://tlogin.usi.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://tlogin.usi.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://tlogin.usi.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.unisi.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDHzCCAgegAwIBAgIUBOyIUS+lpmN+gm0OO7ifYxam4OQwDQYJKoZIhvcNAQEL
+BQAwGDEWMBQGA1UEAwwNdGxvZ2luLnVzaS5jaDAeFw0xNzEwMTgxNDIwNDBaFw0y
+MDEwMTgxNDIwNDBaMBgxFjAUBgNVBAMMDXRsb2dpbi51c2kuY2gwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDE7R4SsETnsTZK9iftZrGv6cBk9MTK8rBg
+Z36yGyQJsb29ro6s3l6+Wz1nC2sgKru2AkX8b1qwdYeSFFvrOj8Ux+Pu/CtDqaXs
+etICm3I4d2BPuaLtw+5yWfPb2X+nKBYlrNdNlCII152YzBxVuaIqwShdCyCxhmQN
+a8mk4KinfvxrkFyIcdtBC05ogY8g0XJGwPSkh+KkggGZjTqWqOGbMhxCJgdb/f7a
+tLNH8Pg5BfhpytQ6P3AvX8CKtLOZ/3EUuPdmQpmLKH23P31MQm4UOV0cZKWSvFOX
+MAetmnejFq8L+AVTtkjNeVpApwK25SJBFhf4H/Xcxf6sGjanyHElAgMBAAGjYTBf
+MB0GA1UdDgQWBBSwHQEgW9WPPJ9FvI8gTAJVOxiYlDA+BgNVHREENzA1gg10bG9n
+aW4udXNpLmNohiRodHRwczovL3Rsb2dpbi51c2kuY2gvaWRwL3NoaWJib2xldGgw
+DQYJKoZIhvcNAQELBQADggEBAA9/J7+Ec99rtgh6WOb6mMCVU7yMTSL/l9y5Y1hV
+h/le4sLpHhCYBBwVEDqjOhtZBczwpfJNx5NHwK1k/5upsgAOyF3ASfxM91MrRcfL
+Ed3voQETuZ158NxYVc6jVoEhIZd41varJgqXWq3udYtX5qxzB9mtkQAFtEHwb5Ef
+7Y61JIhlZUsM3amqPrglaGgg6Cp+kzGaOLJfMwo/P1liWaQOxctM0DUvm1xBzOpA
+PIR6n9TcuIrrjSOKccQkfLNs+WFFD0pLZgl7Qcv18y7031/mQLDi4SF2R/zZuolo
+1uM1eVF6cluVa5tdvdgOSrnIfoLKHQskjzm7Xwd4vHrI924=
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://tlogin.usi.ch:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://tlogin.usi.ch:8443/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">test.unisi.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">Universita della Svizzera Italiana</OrganizationDisplayName>
+			<OrganizationDisplayName xml:lang="it">Universita della Svizzera Italiana</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.test.unisi.ch/</OrganizationURL>
+			<OrganizationURL xml:lang="it">http://www.test.unisi.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	<!-- Test Virtual Home Organization -->
+	<md:EntityDescriptor entityID="https://aai-logon.test.vho-switchaai.ch/idp/shibboleth">
+		<Extensions>
+			<mdattr:EntityAttributes xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+				<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://macedir.org/entity-category-support" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+					<saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+					<saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+				</saml:Attribute>
+      <saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:oasis:names:tc:SAML:attribute:subject-id:req" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>none</saml:AttributeValue>
+      </saml:Attribute>
+				
+			</mdattr:EntityAttributes>
+
+		</Extensions>
+		<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.vho-switchaai.ch</shibmd:Scope>
+				<mdui:UIInfo>
+					<mdui:DisplayName xml:lang="en">Test Virtual Home Organization</mdui:DisplayName>
+					<mdui:Description xml:lang="en">Test Virtual Home Organization</mdui:Description>
+				</mdui:UIInfo>
+				<mdui:DiscoHints>
+					<mdui:DomainHint>test.vho-switchaai.ch</mdui:DomainHint>
+				</mdui:DiscoHints>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDaTCCAlGgAwIBAgIUZ7vIS8xU/TmcJ01HVYip4nsWptMwDQYJKoZIhvcNAQEF
+BQAwKjEoMCYGA1UEAxMfYWFpLWxvZ29uLnRlc3QudmhvLXN3aXRjaGFhaS5jaDAe
+Fw0wOTAzMTAxNTEzNDFaFw0yOTAzMTAxNTEzNDFaMCoxKDAmBgNVBAMTH2FhaS1s
+b2dvbi50ZXN0LnZoby1zd2l0Y2hhYWkuY2gwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQCNC4WTAZukzr4xx4ysAVeww94z1by8UoCAbkny6M1y5yjskEgX
+lxr0S259v+JZfi2PE/kNzqQwptAS/lPTKMEK1DRvtI+z2FX4cQ287HTBTtW63IFb
+h+a6a6/ZCdWswIgs6p9HqECGVwubrSieCW0oU95F9BGr2ev3Fjey0CT4Mopvab75
+JlW4MoQMERk98rCCzHJ/WMDS7paLfHtj1Mk2Gzi3rbg/NpHm2HvG4J9CzBY2I3Ws
+ASrxzH+J/qXmWmMRLBDLtWfPGTGLIrzVg8fiNEpcoj0GktkerxbioETDUtA+aUHS
+Er+KjWi/dFkd4Qk6ua4KmdkTOL1d0Cm0cvUXAgMBAAGjgYYwgYMwYgYDVR0RBFsw
+WYIfYWFpLWxvZ29uLnRlc3QudmhvLXN3aXRjaGFhaS5jaIY2aHR0cHM6Ly9hYWkt
+bG9nb24udGVzdC52aG8tc3dpdGNoYWFpLmNoL2lkcC9zaGliYm9sZXRoMB0GA1Ud
+DgQWBBQiAxs/3pBG53eHoOVcglQpkqcq6jANBgkqhkiG9w0BAQUFAAOCAQEAGt92
+GCuEkm7qWp2EKwXbr7P7J+4posn2xdnoKu9t0XSIb+af0P00TPznmRcVVE54n/oq
+32GkvrT9QVkjSOy83Jwr2ChWFlmdMHo/56YJy0vXO8ZMldASEVHIepfCLsLHwjcR
+GpXVwxl8goQbRPTUxiHcHvBTcDjXews/7nxLiIrm7oyfFntHD4ZGtG/hWbORBsgR
+42endMvS91hw9e1bh90skww+Iiy7tkdRw+xuPJjf5MwuJjb6+Ix8gzv1i3tGWagE
+B4BJMLwKgJTcRqjnSWQyoZGsfJKhPYO3ySW9Dv8A5lEf2KgqltGLwNep/LXm5yXG
+NaJ5zpd0pEiy3dSqZQ==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon.test.vho-switchaai.ch:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+			<ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon.test.vho-switchaai.ch:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+			<md:SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest" Location="https://aai-logon.test.vho-switchaai.ch/idp/profile/Shibboleth/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://aai-logon.test.vho-switchaai.ch/idp/profile/SAML2/Redirect/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://aai-logon.test.vho-switchaai.ch/idp/profile/SAML2/POST/SSO"/>
+			<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://aai-logon.test.vho-switchaai.ch/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+		</md:IDPSSODescriptor>
+		<AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol">
+			<Extensions>
+				<shibmd:Scope regexp="false">test.vho-switchaai.ch</shibmd:Scope>
+			</Extensions>
+			<md:KeyDescriptor use="signing">
+				<ds:KeyInfo>
+					<ds:X509Data>
+						<ds:X509Certificate>
+MIIDaTCCAlGgAwIBAgIUZ7vIS8xU/TmcJ01HVYip4nsWptMwDQYJKoZIhvcNAQEF
+BQAwKjEoMCYGA1UEAxMfYWFpLWxvZ29uLnRlc3QudmhvLXN3aXRjaGFhaS5jaDAe
+Fw0wOTAzMTAxNTEzNDFaFw0yOTAzMTAxNTEzNDFaMCoxKDAmBgNVBAMTH2FhaS1s
+b2dvbi50ZXN0LnZoby1zd2l0Y2hhYWkuY2gwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQCNC4WTAZukzr4xx4ysAVeww94z1by8UoCAbkny6M1y5yjskEgX
+lxr0S259v+JZfi2PE/kNzqQwptAS/lPTKMEK1DRvtI+z2FX4cQ287HTBTtW63IFb
+h+a6a6/ZCdWswIgs6p9HqECGVwubrSieCW0oU95F9BGr2ev3Fjey0CT4Mopvab75
+JlW4MoQMERk98rCCzHJ/WMDS7paLfHtj1Mk2Gzi3rbg/NpHm2HvG4J9CzBY2I3Ws
+ASrxzH+J/qXmWmMRLBDLtWfPGTGLIrzVg8fiNEpcoj0GktkerxbioETDUtA+aUHS
+Er+KjWi/dFkd4Qk6ua4KmdkTOL1d0Cm0cvUXAgMBAAGjgYYwgYMwYgYDVR0RBFsw
+WYIfYWFpLWxvZ29uLnRlc3QudmhvLXN3aXRjaGFhaS5jaIY2aHR0cHM6Ly9hYWkt
+bG9nb24udGVzdC52aG8tc3dpdGNoYWFpLmNoL2lkcC9zaGliYm9sZXRoMB0GA1Ud
+DgQWBBQiAxs/3pBG53eHoOVcglQpkqcq6jANBgkqhkiG9w0BAQUFAAOCAQEAGt92
+GCuEkm7qWp2EKwXbr7P7J+4posn2xdnoKu9t0XSIb+af0P00TPznmRcVVE54n/oq
+32GkvrT9QVkjSOy83Jwr2ChWFlmdMHo/56YJy0vXO8ZMldASEVHIepfCLsLHwjcR
+GpXVwxl8goQbRPTUxiHcHvBTcDjXews/7nxLiIrm7oyfFntHD4ZGtG/hWbORBsgR
+42endMvS91hw9e1bh90skww+Iiy7tkdRw+xuPJjf5MwuJjb6+Ix8gzv1i3tGWagE
+B4BJMLwKgJTcRqjnSWQyoZGsfJKhPYO3ySW9Dv8A5lEf2KgqltGLwNep/LXm5yXG
+NaJ5zpd0pEiy3dSqZQ==
+						</ds:X509Certificate>
+					</ds:X509Data>
+				</ds:KeyInfo>
+			</md:KeyDescriptor>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding" Location="https://aai-logon.test.vho-switchaai.ch:8443/idp/profile/SAML1/SOAP/AttributeQuery"/>
+			<AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://aai-logon.test.vho-switchaai.ch:8443/idp/profile/SAML2/SOAP/AttributeQuery"/>
+            <md:NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+		</AttributeAuthorityDescriptor>
+		<Organization>
+			<OrganizationName xml:lang="en">test.vho-switchaai.ch</OrganizationName>
+			<OrganizationDisplayName xml:lang="en">Test Virtual Home Organization</OrganizationDisplayName>
+			<OrganizationURL xml:lang="en">http://www.test.vho-switchaai.ch/</OrganizationURL>
+		</Organization>
+	</md:EntityDescriptor>
+
+	
+
+</md:EntitiesDescriptor>

--- a/test/samly_idp_data_test.exs
+++ b/test/samly_idp_data_test.exs
@@ -290,7 +290,7 @@ defmodule SamlyIdpDataTest do
     assert idp_data.nameid_format == :unknown
   end
 
-  test "valid federation config", %{sps: sps} do
+  test "Federation metadata can be provided for an idp along with its entityID", %{sps: sps} do
     idp_data = IdpData.load_provider(@federation_idp_config1, sps)
     %IdpData{
       entity_id: entity_id,
@@ -298,7 +298,7 @@ defmodule SamlyIdpDataTest do
       sso_redirect_url: sso_redirect_url,
       slo_redirect_url: slo_redirect_url,
       slo_post_url: nil,
-      nameid_format: id_formats,
+      nameid_format: id_format,
       certs: certs
     } = idp_data
 
@@ -308,8 +308,6 @@ defmodule SamlyIdpDataTest do
     assert slo_redirect_url == "https://login.test.eduid.ch/idp/profile/SAML2/Redirect/SLO"
 
     assert 1 == length(certs)
-    # TODO Should we keep a list of nameid formats or just one value?
-    assert ["urn:oasis:names:tc:SAML:2.0:nameid-format:persistent", "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"]
-    == id_formats |> Enum.map(&to_string/1) |> Enum.sort()
+    assert 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient' == id_format
   end
 end


### PR DESCRIPTION
SAML metadata can specify multiple IDP providers in one file. As for now Samly is not supporting this.

This PR introduces a possibility of using federation metadata in IDP config. A developer only needs to provide `entity_id` of an IDP alongside `metadata_file` option.

Closed #47